### PR TITLE
Increase rows per page in DataTables

### DIFF
--- a/components/EntriesTable.tsx
+++ b/components/EntriesTable.tsx
@@ -185,6 +185,8 @@ export default function EntriesTable({
       data={filteredEntries}
       progressPending={loading}
       pagination
+      paginationPerPage={25}
+      paginationRowsPerPageOptions={[10, 25, 50, 100]}
       highlightOnHover
       striped
       subHeader

--- a/components/ProjectsTable.tsx
+++ b/components/ProjectsTable.tsx
@@ -172,6 +172,8 @@ export default function ProjectsTable({
       data={filteredProjects}
       progressPending={loading}
       pagination
+      paginationPerPage={25}
+      paginationRowsPerPageOptions={[10, 25, 50, 100]}
       highlightOnHover
       striped
       subHeader

--- a/components/UserTable.tsx
+++ b/components/UserTable.tsx
@@ -135,6 +135,8 @@ export default function UserTable({
       data={filteredUsers}
       progressPending={loading}
       pagination
+      paginationPerPage={25}
+      paginationRowsPerPageOptions={[10, 25, 50, 100]}
       highlightOnHover
       striped
       subHeader


### PR DESCRIPTION
Default to 25, options for 10,25,50,100