### PR TITLE
fix bad permission setting in bulkadd page

### DIFF
--- a/app/(main-layout)/bulkAdd/[id]/page.tsx
+++ b/app/(main-layout)/bulkAdd/[id]/page.tsx
@@ -22,7 +22,7 @@ export default async function BulkAddPage({
     permissions: { canEdit, canPrint, nonOwnerEditor },
   } = await getUserInfo(id);
 
-  if (canEdit) {
+  if (!canEdit) {
     return unauthorized();
   }
   if (project) {


### PR DESCRIPTION
fix bad permission setting disallowing users from accessing bulkAdd page if canEdit=true