### PR TITLE
add support for printing a single bibEntry from a project

### DIFF
--- a/app/(main-layout)/project/[id]/page.tsx
+++ b/app/(main-layout)/project/[id]/page.tsx
@@ -60,7 +60,11 @@ export default async function ProjectPage({
         />
       </div>
       {bibEntries && bibEntries.data?.entries && user ? (
-        <EntriesTable entries={bibEntries.data?.entries} canEdit={canEdit} />
+        <EntriesTable
+          entries={bibEntries.data?.entries}
+          canEdit={canEdit}
+          canPrint={canPrint}
+        />
       ) : (
         <p>No bibliography entries found.</p>
       )}

--- a/app/(main-layout)/slips/[id]/ClientMultipagePdf.tsx
+++ b/app/(main-layout)/slips/[id]/ClientMultipagePdf.tsx
@@ -1,12 +1,17 @@
 'use client';
 import { useParams } from 'next/navigation';
+import { spec } from 'node:test/reporters';
 
 export default function MultiPagePdf() {
-  const { id } = useParams();
+  const { id, specificBibEntry } = useParams();
+  // generate different url param based on whether or not a single BibEntry is called for
+  const idToPrint = specificBibEntry ? `${id}--${specificBibEntry}` : id;
   return (
     <div style={{ height: '100vh' }}>
       <iframe
-        src={`${process.env.NEXT_PUBLIC_APP_BASEPATH ?? ''}/api/slipsPdf/${id}`}
+        src={`${
+          process.env.NEXT_PUBLIC_APP_BASEPATH ?? ''
+        }/api/slipsPdf/${idToPrint}`}
         title="Printing Slips"
         style={{ width: '100%', height: '100%', border: 'none' }}
       />

--- a/app/(main-layout)/slips/[id]/page.tsx
+++ b/app/(main-layout)/slips/[id]/page.tsx
@@ -15,11 +15,11 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 type PageProps = {
-  params: Promise<{ id: string }>;
+  params: Promise<{ id: string; specificBibEntry: string }>;
 };
 
 export default async function PdfWrapper({ params }: PageProps) {
-  const { id } = await params;
+  const { id, specificBibEntry } = await params;
   const { project, error } = await getProject({ id });
   const {
     permissions: { canPrint },

--- a/app/actions/getEntries.ts
+++ b/app/actions/getEntries.ts
@@ -2,13 +2,17 @@
 import logger from '@/lib/logger';
 import { db } from '@/lib/db';
 import { EntryWithItems } from '@/types/EntryWithItems';
+import { Prisma } from '@prisma/client';
 
 type EntriesResult = {
   entries: EntryWithItems[];
   totalCount: number;
 };
 
-async function getEntries(projectId: string): Promise<{
+async function getEntries(
+  projectId: string,
+  specificBibEntry?: string
+): Promise<{
   data?: EntriesResult;
   error?: string;
 }> {
@@ -17,6 +21,8 @@ async function getEntries(projectId: string): Promise<{
     const entries = await db.bibEntry.findMany({
       where: {
         projectId: parseInt(projectId, 10),
+        // limit to one bib entry if called for:
+        ...(specificBibEntry ? { id: specificBibEntry } : {}),
       },
       include: {
         items: true, // Include related items

--- a/app/api/slipsPdf/[...slug]/route.tsx
+++ b/app/api/slipsPdf/[...slug]/route.tsx
@@ -14,8 +14,9 @@ export async function GET(
   { params }: { params: Promise<{ slug: string[] }> }
 ) {
   const { slug } = await params;
-  const id = slug[0]; // why this two-step? idk but it seemed necessary to build
-  const { data } = await getEntries(id);
+  const [id, specificBibEntry] = slug[0].split('--');
+  // note: specificBibEntry is optional and is ignored if absent
+  const { data } = await getEntries(id, specificBibEntry);
   const { project } = await getProject({ id });
   const user = await checkUser();
 

--- a/components/EntriesTable.tsx
+++ b/components/EntriesTable.tsx
@@ -13,11 +13,13 @@ import { EntryWithItems } from '@/types/EntryWithItems';
 interface EntriesTableProps {
   entries?: EntryWithItems[];
   canEdit?: boolean;
+  canPrint?: boolean;
 }
 
 export default function EntriesTable({
   entries = [],
   canEdit = false,
+  canPrint = false,
 }: EntriesTableProps) {
   const [currentEntries, setCurrentEntries] = useState<EntryWithItems[]>([]); // Track current entries
   const [filteredEntries, setFilteredEntries] = useState<EntryWithItems[]>([]);
@@ -179,6 +181,14 @@ export default function EntriesTable({
             >
               Edit
             </Link>
+            {canPrint && (
+              <Link
+                href={`/slips/${row.projectId}--${row.id}`}
+                className="me-1 btn btn-outline-primary btn-sm"
+              >
+                Print
+              </Link>
+            )}
             <DeleteButton
               label=""
               onDelete={() =>


### PR DESCRIPTION
* closes #194 
* adds an optional specificBibEntry in the getEntries action; fetches only entries based on that id when passed
* adds a "Print" button to one each line of the EntriesTable, which passes both the projectId and the Entries.id to getEntries