### PR TITLE
gracefully handle print slips when there are no entries

### DIFF
--- a/components/MultiPageHtml.tsx
+++ b/components/MultiPageHtml.tsx
@@ -22,6 +22,9 @@ export const MultiPageHtml = ({ books }: { books: RequestSlipProps[] }) => {
     })
     .filter((entry) => Array.isArray(entry));
 
+  if (!pairsArr[0] || !pairsArr[0][0]) {
+    return <div className="m-5">No entries to print.</div>;
+  }
   pairsArr[0][0].displayPrintButton = true; // display print at top of first page
 
   return (


### PR DESCRIPTION
* addresses #306 
* gives a message instead of a NextJs error on no entries