### PR TITLE
limit printed page height to 279mm

### DIFF
--- a/components/MultiPageHtml.module.css
+++ b/components/MultiPageHtml.module.css
@@ -11,8 +11,8 @@
     overflow: hidden;
     position: relative;
     box-sizing: border-box;
-    outline: 3mm black solid;
-    outline-offset: -3mm;
+    /* outline: 3mm black solid;
+    outline-offset: -3mm; */
 }
 .notLastPage {
     page-break-after: always;


### PR DESCRIPTION
* fixes #300 -- at 280mm (previous) it overflowed for some printers. 