### PR TITLE
update aspace package, account for more data variation

### DIFF
--- a/app/actions/aspaceSearch.ts
+++ b/app/actions/aspaceSearch.ts
@@ -16,6 +16,7 @@ import type {
   ItemDataDraft,
   CatalogSearchResult,
 } from '@/lib/catalogs/types';
+import { ZodError } from 'zod';
 
 export async function getClient() {
   try {
@@ -54,13 +55,14 @@ export async function searchByUrl(url: string, client: AspaceClient) {
     const publicBaseUrl = process.env.ASPACE_PUBLIC_BASE_URL ?? '';
     const apiBaseUrl = process.env.ASPACE_API_BASE_URL ?? '';
     url = url.replace(publicBaseUrl, apiBaseUrl);
-    logger.verbose(`fetching url: ${url}`);
+    logger.verbose(`aspaceSearch/searchByUrl fetching: ${url}`);
     const raw = await client.getUrl(url, {
       resolve: ['linked_agents', 'repository', 'top_container'],
     });
     switch (true) {
       // https://archivesstaff.lib.miamioh.edu/api/repositories/2/resources/634
       case /repositories\/\d+\/resources\/\d+/.test(url): {
+        logger.verbose('aspaceSearch.searchByUrl found repoResources');
         const parsed = repoResourcesSchema.parse(raw);
         const argusData = repoResourcesToDraft(parsed);
         logger.verbose(JSON.stringify(argusData, null, 2));
@@ -71,6 +73,8 @@ export async function searchByUrl(url: string, client: AspaceClient) {
 
       // https://archivesstaff.lib.miamioh.edu/api/repositories/2/top_containers/7838
       case /repositories\/\d+\/top_containers\/\d+/.test(url): {
+        logger.verbose('aspaceSearch.searchByUrl found topContainers');
+
         const parsed = repoTopContainerSchema.parse(raw);
         const argusData = repoTopContainerToDraft(parsed);
         logger.verbose(`ArgusData for repoTpContainer: ${argusData}`);
@@ -78,9 +82,12 @@ export async function searchByUrl(url: string, client: AspaceClient) {
         return argusData;
         break;
       }
-
+      // https://archivesspace.lib.miamioh.edu/repositories/2/archival_objects/13405
+      // https://archivesstaff.lib.miamioh.edu/api/repositories/2/archival_objects/13282
       // https://archivesstaff.lib.miamioh.edu/api/repositories/2/archival_objects/5616
       case /repositories\/\d+\/archival_objects\/\d+/.test(url): {
+        logger.verbose('aspaceSearch.searchByUrl found archivalObjects');
+
         const parsed = repoArchivalObjectSchema.parse(raw);
         const argusData = repoArchivalObjectToDraft(parsed);
         logger.verbose(argusData);
@@ -96,8 +103,13 @@ export async function searchByUrl(url: string, client: AspaceClient) {
       }
     }
   } catch (error) {
-    error instanceof Error && logger.error(error.message);
-    throw error;
+    if (error instanceof ZodError) {
+      logger.error(`Zod parsing error: ${error.message}`);
+      throw error;
+    } else {
+      error instanceof Error && logger.error(error.message);
+      throw error;
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@clerk/nextjs": "^7.0.4",
         "@kenxirwin/alma-search": "^0.2.0",
-        "@kenxirwin/archives-space-api-client": "^0.2.0",
+        "@kenxirwin/archives-space-api-client": "^0.2.1",
         "@prisma/client": "^6.13.0",
         "bootstrap": "^5.3.7",
         "datatables.net-dt": "^2.3.2",
@@ -912,9 +912,9 @@
       "license": "MIT"
     },
     "node_modules/@kenxirwin/archives-space-api-client": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@kenxirwin/archives-space-api-client/-/archives-space-api-client-0.2.0.tgz",
-      "integrity": "sha512-QFROxcyhb85A3GaX5YI+fx4A5Xan6mZUCF6E8lmuGwefW/AvjInglI3YG1C7F4B+9e4qigzgCAjyeGgtH/3TTg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@kenxirwin/archives-space-api-client/-/archives-space-api-client-0.2.1.tgz",
+      "integrity": "sha512-vD5F9iJDQYgWAeGwTDxJszvZvKlIIY+5TAAH/TIpFN2BUzncicXhaPCvVu0EH1Umm7xvxpW/9jS1xR6wtXbH6Q==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@clerk/nextjs": "^7.0.4",
     "@kenxirwin/alma-search": "^0.2.0",
-    "@kenxirwin/archives-space-api-client": "^0.2.0",
+    "@kenxirwin/archives-space-api-client": "^0.2.1",
     "@prisma/client": "^6.13.0",
     "bootstrap": "^5.3.7",
     "datatables.net-dt": "^2.3.2",


### PR DESCRIPTION
* bump @kenxirwin/archives-space-api-client: "^0.2.1
* clearer log message on Zod errors when parsing aspace data response