### PR TITLE
Implement custom/local call number overrides extension for ArchivesSpace 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Institution-specific ArchivesSpace call-number overrides — this file is a
+# per-installation extension point (see lib/catalogs/aspace/callNumberOverrides.ts).
+# Upstream should not edit its contents again after initial creation, so local
+# edits here never conflict on `git pull`/rebase from upstream, as long as the
+# merge.ours driver is configured (see README.md).
+lib/catalogs/aspace/callNumberOverrides.ts merge=ours

--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ LOG_LEVEL=info #info is the default, choose from: error,warn,info,verbose,debug,
    - Set `NEXT_PUBLIC_IS_DEV_ENV`. Should be `false` for production; when true, will display some ugly/useful JSON data on some results pages.
 8. When the site is ready to go into production (i.e., after testing), use the Google Developer Console to create a project to handle authentication. Provide the Google project configuration to Clerk to let Google handle the authentication and have Clerk manage users. Refer to Clerk's documentation on [Deploying to production](https://clerk.com/docs/guides/development/deployment/production) for and this [video tutorial](https://youtu.be/qKU6MQp-g7w?si=Qq6pp1VvRVp64edq) guidance.
 
+### ArchivesSpace call-number customization
+
+Different institutions structure their ArchivesSpace `id_0`/`id_1`/`id_2`/`indicator`/`display_string` fields differently, so call-number parsing is a designated per-installation extension point rather than a one-size-fits-all default.
+
+`lib/catalogs/aspace/callNumberOverrides.ts` ships with empty defaults (today's built-in parsing behavior). To customize call-number parsing for your installation, edit that file directly and implement whichever of the `resources`, `topContainer`, or `archivalObject` `bib`/`item` functions you need — anything left unimplemented falls back to the built-in logic. The function signatures are fully typed against the ArchivesSpace client's response types, so your editor will show you exactly what data is available.
+
+Because this file is meant to diverge per installation, set it up once so future `git pull`s from upstream don't create merge conflicts on your local edits:
+
+```
+git config merge.ours.driver true
+```
+
+This tells git to keep your local version of any file matching a `merge=ours` rule in `.gitattributes` (already configured for `callNumberOverrides.ts`) whenever you merge or pull changes from upstream, instead of trying to merge the two versions. Upstream Argus development should never need to edit this file's contents again after it's created, so in practice this means your customization simply persists across updates.
+
 ## Getting Started (Boilerplate NextJs stuff)
 
 First, run the development server:

--- a/app/actions/aspaceHandleMissingInstances.ts
+++ b/app/actions/aspaceHandleMissingInstances.ts
@@ -15,30 +15,35 @@ export async function HandleMissingInstances(
   parentResourceUrl: string,
   client: AspaceClient,
 ) {
-  console.log(`looking for more info about ${originalUri}`);
+  console.log(`looking for more info about ${parentResourceUrl}`);
   const resourceWithTree: RepoResources = await getResourceTree(
     parentResourceUrl,
     client,
   );
-  //   console.log(`Resource Title: ${resourceWithTree.title}`);
-  //   console.log(
-  //     `find key value pair in tree with record_uri: "${originalUri?.toString()}"`,
-  //   );
+  console.log(`Resource Title: ${resourceWithTree.title}`);
+  console.log(
+    `find key value pair in tree with record_uri: "${originalUri?.toString()}"`,
+  );
   const node = findNodeByKeyValuePair(
     resourceWithTree,
     'record_uri',
     originalUri?.toString(), // not sure why toString is needed, but it is
   );
   const numItems = node.children.length;
-  const firstItemUrl =
-    process.env.ASPACE_API_BASE_URL + node.children[0].record_uri;
-  const firstRecordArgusData = await searchByUrl(firstItemUrl, client);
-  //   console.log(`numItems: ${numItems}`);
-  //   console.log(`first child = ${JSON.stringify(node.children[0])}`);
-  const extraInfo = {
-    numItems,
-    firstItemUrl,
-    firstRecordArgusData,
-  };
-  return extraInfo;
+  console.log(numItems);
+  if (numItems > 0) {
+    const firstItemUrl =
+      process.env.ASPACE_API_BASE_URL + node.children[0].record_uri;
+    const firstRecordArgusData = await searchByUrl(firstItemUrl, client);
+    console.log(`numItems: ${numItems}`);
+    console.log(`first child = ${JSON.stringify(node.children[0])}`);
+    const extraInfo = {
+      numItems,
+      firstItemUrl,
+      firstRecordArgusData,
+    };
+    return extraInfo;
+  } else {
+    return {};
+  }
 }

--- a/app/actions/aspaceHandleMissingInstances.ts
+++ b/app/actions/aspaceHandleMissingInstances.ts
@@ -1,0 +1,44 @@
+/* 
+    This is a more complex approach to identifying items attached to 
+    archival_objects in ArchivesSpace
+*/
+
+import { findNodeByKeyValuePair } from '@/lib/findNodeByKeyValuePair';
+import { getResourceTree, searchByUrl } from './aspaceSearch';
+import type {
+  AspaceClient,
+  RepoResources,
+} from '@kenxirwin/archives-space-api-client';
+
+export async function HandleMissingInstances(
+  originalUri: string,
+  parentResourceUrl: string,
+  client: AspaceClient,
+) {
+  console.log(`looking for more info about ${originalUri}`);
+  const resourceWithTree: RepoResources = await getResourceTree(
+    parentResourceUrl,
+    client,
+  );
+  //   console.log(`Resource Title: ${resourceWithTree.title}`);
+  //   console.log(
+  //     `find key value pair in tree with record_uri: "${originalUri?.toString()}"`,
+  //   );
+  const node = findNodeByKeyValuePair(
+    resourceWithTree,
+    'record_uri',
+    originalUri?.toString(), // not sure why toString is needed, but it is
+  );
+  const numItems = node.children.length;
+  const firstItemUrl =
+    process.env.ASPACE_API_BASE_URL + node.children[0].record_uri;
+  const firstRecordArgusData = await searchByUrl(firstItemUrl, client);
+  //   console.log(`numItems: ${numItems}`);
+  //   console.log(`first child = ${JSON.stringify(node.children[0])}`);
+  const extraInfo = {
+    numItems,
+    firstItemUrl,
+    firstRecordArgusData,
+  };
+  return extraInfo;
+}

--- a/app/actions/aspaceSearch.ts
+++ b/app/actions/aspaceSearch.ts
@@ -20,6 +20,7 @@ import type {
 import { ZodError } from 'zod';
 import { findNodeByKeyValuePair } from '@/lib/findNodeByKeyValuePair';
 import { cli } from 'winston/lib/winston/config';
+import { HandleMissingInstances } from './aspaceHandleMissingInstances';
 
 export interface ArchivalObjectExtraInfo {
   numItems: number;
@@ -119,32 +120,40 @@ export async function searchByUrl(url: string, client: AspaceClient) {
         if (parsed.instances.length == 0) {
           const parentResourceUrl = parsed.resource.ref;
           const originalUri = url.match(/\/repositories\/.*/);
-          console.log(`looking for more info about ${originalUri}`);
-          const resourceWithTree: RepoResources = await getResourceTree(
-            parentResourceUrl,
-            client,
-          );
-          console.log(`Resource Title: ${resourceWithTree.title}`);
-          console.log(
-            `find key value pair in tree with record_uri: "${originalUri?.toString()}"`,
-          );
-          const node = findNodeByKeyValuePair(
-            resourceWithTree,
-            'record_uri',
-            originalUri?.toString(), // not sure why toString is needed, but it is
-          );
-          const numItems = node.children.length;
-          const firstItemUrl = apiBaseUrl + node.children[0].record_uri;
-          const firstRecordArgusData = await searchByUrl(firstItemUrl, client);
-          console.log(`numItems: ${numItems}`);
-          console.log(`first child = ${JSON.stringify(node.children[0])}`);
-          extraInfo = {
-            numItems,
-            firstItemUrl,
-            firstRecordArgusData,
-          };
+          if (originalUri !== null) {
+            extraInfo = await HandleMissingInstances(
+              originalUri.toString(),
+              parentResourceUrl,
+              client,
+            );
+          }
         }
-        console.log(`extraInfo: ${JSON.stringify(extraInfo)}`);
+        //   console.log(`looking for more info about ${originalUri}`);
+        //   const resourceWithTree: RepoResources = await getResourceTree(
+        //     parentResourceUrl,
+        //     client,
+        //   );
+        //   console.log(`Resource Title: ${resourceWithTree.title}`);
+        //   console.log(
+        //     `find key value pair in tree with record_uri: "${originalUri?.toString()}"`,
+        //   );
+        //   const node = findNodeByKeyValuePair(
+        //     resourceWithTree,
+        //     'record_uri',
+        //     originalUri?.toString(), // not sure why toString is needed, but it is
+        //   );
+        //   const numItems = node.children.length;
+        //   const firstItemUrl = apiBaseUrl + node.children[0].record_uri;
+        //   const firstRecordArgusData = await searchByUrl(firstItemUrl, client);
+        //   console.log(`numItems: ${numItems}`);
+        //   console.log(`first child = ${JSON.stringify(node.children[0])}`);
+        //   extraInfo = {
+        //     numItems,
+        //     firstItemUrl,
+        //     firstRecordArgusData,
+        //   };
+        // }
+        // console.log(`extraInfo: ${JSON.stringify(extraInfo)}`);
         /* End special section dealing with missing archival_object data */
 
         let argusData;

--- a/app/actions/aspaceSearch.ts
+++ b/app/actions/aspaceSearch.ts
@@ -6,6 +6,7 @@ import {
   repoArchivalObjectSchema,
 } from '@kenxirwin/archives-space-api-client';
 import logger from '@/lib/logger';
+import callNumberOverrides from '@/lib/catalogs/aspace/callNumberOverrides';
 import type {
   RepoArchivalObject,
   RepoResources,
@@ -124,7 +125,9 @@ function repoResourcesToDraft(data: RepoResources) {
         .filter((entry) => entry.role == 'creator')
         .map((entry) => entry._resolved?.names[0].sort_name)
         .join('; ') ?? 'Unknown',
-    callNumber: `${data.id_0}--${data.id_1}--${data.id_2}`,
+    callNumber:
+      callNumberOverrides.resources?.bib?.(data) ??
+      `${data.id_0}--${data.id_1}--${data.id_2}`,
     itemTitle: data.title,
     catalog: 'ASPACE',
     catalogId: data.uri,
@@ -143,12 +146,14 @@ function repoResourcesToDraft(data: RepoResources) {
     barcode: '',
     box: '',
     call_number:
-      item.sub_container.top_container._resolved?.display_string ?? '',
+      callNumberOverrides.resources?.item?.(item, data) ??
+      item.sub_container.top_container._resolved?.display_string ??
+      '',
     copy_id: '',
-    description:
-      item.sub_container.top_container._resolved?.long_display_string ?? '',
+    description: '',
+    // item.sub_container.top_container._resolved?.long_display_string ?? '',
     folder: '',
-    location_code: data.repository._resolved?.slug ?? '',
+    location_code: '', //data.repository._resolved?.slug ?? '',
     location_name: data.repository._resolved?.name ?? '',
     ms: '',
   }));
@@ -162,7 +167,7 @@ function repoResourcesToDraft(data: RepoResources) {
 function repoTopContainerToDraft(data: RepoTopContainer) {
   const bibData: BibDataDraft = {
     author: 'Unknown',
-    callNumber: data.indicator,
+    callNumber: callNumberOverrides.topContainer?.bib?.(data) ?? data.indicator,
     itemTitle: data.long_display_string,
     catalog: 'ASPACE',
     catalogId: data.uri,
@@ -181,7 +186,8 @@ function repoTopContainerToDraft(data: RepoTopContainer) {
       clientKey: `item-0`,
       barcode: '',
       box: '',
-      call_number: data.indicator,
+      call_number:
+        callNumberOverrides.topContainer?.item?.(data) ?? data.indicator,
       copy_id: '',
       description: data.indicator,
       folder: '',
@@ -206,12 +212,14 @@ function repoArchivalObjectToDraft(data: RepoArchivalObject) {
         .map((entry) => entry._resolved?.names[0].sort_name)
         .join('; ') ?? 'Unknown',
     callNumber:
+      callNumberOverrides.archivalObject?.bib?.(data) ??
       data.instances
         .map(
           (instance) =>
             instance.sub_container.top_container._resolved?.indicator,
         )
-        .join('; ') ?? '',
+        .join('; ') ??
+      '',
     itemTitle: data.title,
     catalog: 'ASPACE',
     catalogId: data.uri,
@@ -220,7 +228,11 @@ function repoArchivalObjectToDraft(data: RepoArchivalObject) {
     location_display: data.repository._resolved?.name ?? '',
     notes: '',
     pub_date:
-      (data.dates && `${data.dates[0].begin} - ${data.dates[0].end}`) ?? '',
+      (data.dates &&
+        data.dates[0] &&
+        (data.dates[0].begin || data.dates[0].end) &&
+        `${data.dates[0]?.begin ?? ''} - ${data.dates[0]?.end ?? ''}`) ??
+      '',
     publisher: null,
     totalItems: 1,
     url: data.uri,
@@ -231,7 +243,9 @@ function repoArchivalObjectToDraft(data: RepoArchivalObject) {
     barcode: '',
     box: '',
     call_number:
-      item.sub_container.top_container._resolved?.display_string ?? '',
+      callNumberOverrides.archivalObject?.item?.(item, data) ??
+      item.sub_container.top_container._resolved?.display_string ??
+      '',
     copy_id: '',
     description:
       item.sub_container.top_container._resolved?.long_display_string ?? '',

--- a/app/actions/aspaceSearch.ts
+++ b/app/actions/aspaceSearch.ts
@@ -118,7 +118,7 @@ export async function searchByUrl(url: string, client: AspaceClient) {
  * repoResourcesToDraft
  */
 
-function repoResourcesToDraft(data: RepoResources, url) {
+function repoResourcesToDraft(data: RepoResources, url: string) {
   const bibData: BibDataDraft = {
     author:
       data.linked_agents
@@ -164,7 +164,7 @@ function repoResourcesToDraft(data: RepoResources, url) {
 /*
  * repoTopContainerToDraft
  */
-function repoTopContainerToDraft(data: RepoTopContainer, url) {
+function repoTopContainerToDraft(data: RepoTopContainer, url: string) {
   const bibData: BibDataDraft = {
     author: 'Unknown',
     callNumber: callNumberOverrides.topContainer?.bib?.(data) ?? data.indicator,
@@ -204,7 +204,7 @@ function repoTopContainerToDraft(data: RepoTopContainer, url) {
  * repoArchivalObjectToDraft
  */
 
-function repoArchivalObjectToDraft(data: RepoArchivalObject, url) {
+function repoArchivalObjectToDraft(data: RepoArchivalObject, url: string) {
   const bibData: BibDataDraft = {
     author:
       data.linked_agents

--- a/app/actions/aspaceSearch.ts
+++ b/app/actions/aspaceSearch.ts
@@ -231,7 +231,7 @@ const getItems = (data: RepoArchivalObject) => {
         box: '',
         call_number: callNumber ?? '',
         copy_id: '',
-        description: callNumber ?? '',
+        description: '',
         folder: '',
         location_code: data.repository._resolved?.slug ?? '',
         location_name: data.repository._resolved?.name ?? '',

--- a/app/actions/aspaceSearch.ts
+++ b/app/actions/aspaceSearch.ts
@@ -77,6 +77,7 @@ export async function searchByUrl(url: string, client: AspaceClient) {
     const publicBaseUrl = process.env.ASPACE_PUBLIC_BASE_URL ?? '';
     const apiBaseUrl = process.env.ASPACE_API_BASE_URL ?? '';
     url = url.replace(publicBaseUrl, apiBaseUrl);
+    const publicUrl = url.replace(apiBaseUrl, publicBaseUrl);
     logger.verbose(`aspaceSearch/searchByUrl fetching: ${url}`);
     const raw = await client.getUrl(url, {
       resolve: ['linked_agents', 'repository', 'top_container'],
@@ -87,7 +88,7 @@ export async function searchByUrl(url: string, client: AspaceClient) {
       case /repositories\/\d+\/resources\/\d+/.test(url): {
         logger.verbose('aspaceSearch.searchByUrl found repoResources');
         const parsed = repoResourcesSchema.parse(raw);
-        const argusData = repoResourcesToDraft(parsed, url);
+        const argusData = repoResourcesToDraft(parsed, publicUrl);
         logger.verbose(JSON.stringify(argusData, null, 2));
         logger.verbose('type: resources');
         return argusData;
@@ -99,7 +100,7 @@ export async function searchByUrl(url: string, client: AspaceClient) {
         logger.verbose('aspaceSearch.searchByUrl found topContainers');
 
         const parsed = repoTopContainerSchema.parse(raw);
-        const argusData = repoTopContainerToDraft(parsed, url);
+        const argusData = repoTopContainerToDraft(parsed, publicUrl);
         logger.verbose(`ArgusData for repoTpContainer: ${argusData}`);
         logger.verbose('type: top containers');
         return argusData;
@@ -160,9 +161,9 @@ export async function searchByUrl(url: string, client: AspaceClient) {
 
         let argusData;
         if (Object.keys(extraInfo).length > 0) {
-          argusData = repoArchivalObjectToDraft(parsed, url, extraInfo);
+          argusData = repoArchivalObjectToDraft(parsed, publicUrl, extraInfo);
         } else {
-          argusData = repoArchivalObjectToDraft(parsed, url);
+          argusData = repoArchivalObjectToDraft(parsed, publicUrl);
         }
         logger.verbose(argusData);
         logger.verbose('type: archival objects');

--- a/app/actions/aspaceSearch.ts
+++ b/app/actions/aspaceSearch.ts
@@ -18,6 +18,14 @@ import type {
   CatalogSearchResult,
 } from '@/lib/catalogs/types';
 import { ZodError } from 'zod';
+import { findNodeByKeyValuePair } from '@/lib/findNodeByKeyValuePair';
+import { cli } from 'winston/lib/winston/config';
+
+export interface ArchivalObjectExtraInfo {
+  numItems: number;
+  firstItemUrl: string;
+  firstRecordArgusData: { bibData: BibDataDraft; itemData: ItemDataDraft };
+}
 
 export async function getClient() {
   try {
@@ -46,6 +54,18 @@ export async function bibHoldingsByUri({ uri }: { uri: string }) {
   return await searchByUrl(url, client);
 }
 
+export async function getResourceTree(url: string, client: AspaceClient) {
+  const publicBaseUrl = process.env.ASPACE_PUBLIC_BASE_URL ?? '';
+  const apiBaseUrl = process.env.ASPACE_API_BASE_URL ?? '';
+  url = url.replace(publicBaseUrl, apiBaseUrl);
+  logger.verbose(`aspaceSearch/getResourceTree fetching: ${url}`);
+  const raw = await client.getUrl(url, {
+    resolve: ['tree'],
+  });
+  const parsed = repoResourcesSchema.parse(raw);
+  return parsed;
+}
+
 export async function searchByUrl(url: string, client: AspaceClient) {
   /* expects a url matching one of these endpoints and schemas: 
 (repoResourcesSchema): for endpoints like /repositories/2/resources/634
@@ -60,6 +80,7 @@ export async function searchByUrl(url: string, client: AspaceClient) {
     const raw = await client.getUrl(url, {
       resolve: ['linked_agents', 'repository', 'top_container'],
     });
+    let extraInfo = {};
     switch (true) {
       // https://archivesstaff.lib.miamioh.edu/api/repositories/2/resources/634
       case /repositories\/\d+\/resources\/\d+/.test(url): {
@@ -90,7 +111,48 @@ export async function searchByUrl(url: string, client: AspaceClient) {
         logger.verbose('aspaceSearch.searchByUrl found archivalObjects');
 
         const parsed = repoArchivalObjectSchema.parse(raw);
-        const argusData = repoArchivalObjectToDraft(parsed, url);
+
+        /* 
+          If the archival object doesn't have any instances, try finding some 
+          by searching down the tree of the main resource
+        */
+        if (parsed.instances.length == 0) {
+          const parentResourceUrl = parsed.resource.ref;
+          const originalUri = url.match(/\/repositories\/.*/);
+          console.log(`looking for more info about ${originalUri}`);
+          const resourceWithTree: RepoResources = await getResourceTree(
+            parentResourceUrl,
+            client,
+          );
+          console.log(`Resource Title: ${resourceWithTree.title}`);
+          console.log(
+            `find key value pair in tree with record_uri: "${originalUri?.toString()}"`,
+          );
+          const node = findNodeByKeyValuePair(
+            resourceWithTree,
+            'record_uri',
+            originalUri?.toString(), // not sure why toString is needed, but it is
+          );
+          const numItems = node.children.length;
+          const firstItemUrl = apiBaseUrl + node.children[0].record_uri;
+          const firstRecordArgusData = await searchByUrl(firstItemUrl, client);
+          console.log(`numItems: ${numItems}`);
+          console.log(`first child = ${JSON.stringify(node.children[0])}`);
+          extraInfo = {
+            numItems,
+            firstItemUrl,
+            firstRecordArgusData,
+          };
+        }
+        console.log(`extraInfo: ${JSON.stringify(extraInfo)}`);
+        /* End special section dealing with missing archival_object data */
+
+        let argusData;
+        if (Object.keys(extraInfo).length > 0) {
+          argusData = repoArchivalObjectToDraft(parsed, url, extraInfo);
+        } else {
+          argusData = repoArchivalObjectToDraft(parsed, url);
+        }
         logger.verbose(argusData);
         logger.verbose('type: archival objects');
         return argusData;
@@ -241,7 +303,11 @@ const getItems = (data: RepoArchivalObject) => {
   }
 };
 
-function repoArchivalObjectToDraft(data: RepoArchivalObject, url: string) {
+function repoArchivalObjectToDraft(
+  data: RepoArchivalObject,
+  url: string,
+  extraInfo?: any,
+) {
   const bibData: BibDataDraft = {
     author:
       data.linked_agents
@@ -249,7 +315,7 @@ function repoArchivalObjectToDraft(data: RepoArchivalObject, url: string) {
         .map((entry) => entry._resolved?.names[0].sort_name)
         .join('; ') ?? 'Unknown',
     callNumber:
-      callNumberOverrides.archivalObject?.bib?.(data) ??
+      callNumberOverrides.archivalObject?.bib?.(data, extraInfo) ??
       data.instances
         .map(
           (instance) =>

--- a/app/actions/aspaceSearch.ts
+++ b/app/actions/aspaceSearch.ts
@@ -65,7 +65,7 @@ export async function searchByUrl(url: string, client: AspaceClient) {
       case /repositories\/\d+\/resources\/\d+/.test(url): {
         logger.verbose('aspaceSearch.searchByUrl found repoResources');
         const parsed = repoResourcesSchema.parse(raw);
-        const argusData = repoResourcesToDraft(parsed);
+        const argusData = repoResourcesToDraft(parsed, url);
         logger.verbose(JSON.stringify(argusData, null, 2));
         logger.verbose('type: resources');
         return argusData;
@@ -77,7 +77,7 @@ export async function searchByUrl(url: string, client: AspaceClient) {
         logger.verbose('aspaceSearch.searchByUrl found topContainers');
 
         const parsed = repoTopContainerSchema.parse(raw);
-        const argusData = repoTopContainerToDraft(parsed);
+        const argusData = repoTopContainerToDraft(parsed, url);
         logger.verbose(`ArgusData for repoTpContainer: ${argusData}`);
         logger.verbose('type: top containers');
         return argusData;
@@ -90,7 +90,7 @@ export async function searchByUrl(url: string, client: AspaceClient) {
         logger.verbose('aspaceSearch.searchByUrl found archivalObjects');
 
         const parsed = repoArchivalObjectSchema.parse(raw);
-        const argusData = repoArchivalObjectToDraft(parsed);
+        const argusData = repoArchivalObjectToDraft(parsed, url);
         logger.verbose(argusData);
         logger.verbose('type: archival objects');
         return argusData;
@@ -118,7 +118,7 @@ export async function searchByUrl(url: string, client: AspaceClient) {
  * repoResourcesToDraft
  */
 
-function repoResourcesToDraft(data: RepoResources) {
+function repoResourcesToDraft(data: RepoResources, url) {
   const bibData: BibDataDraft = {
     author:
       data.linked_agents
@@ -138,7 +138,7 @@ function repoResourcesToDraft(data: RepoResources) {
     pub_date: null,
     publisher: null,
     totalItems: data.instances.length,
-    url: data.uri,
+    url: url,
   };
 
   const itemData: ItemDataDraft[] = data.instances.map((item, index) => ({
@@ -164,7 +164,7 @@ function repoResourcesToDraft(data: RepoResources) {
 /*
  * repoTopContainerToDraft
  */
-function repoTopContainerToDraft(data: RepoTopContainer) {
+function repoTopContainerToDraft(data: RepoTopContainer, url) {
   const bibData: BibDataDraft = {
     author: 'Unknown',
     callNumber: callNumberOverrides.topContainer?.bib?.(data) ?? data.indicator,
@@ -178,7 +178,7 @@ function repoTopContainerToDraft(data: RepoTopContainer) {
     pub_date: null,
     publisher: null,
     totalItems: 1,
-    url: data.uri,
+    url: url,
   };
 
   const itemData: ItemDataDraft[] = [
@@ -204,7 +204,7 @@ function repoTopContainerToDraft(data: RepoTopContainer) {
  * repoArchivalObjectToDraft
  */
 
-function repoArchivalObjectToDraft(data: RepoArchivalObject) {
+function repoArchivalObjectToDraft(data: RepoArchivalObject, url) {
   const bibData: BibDataDraft = {
     author:
       data.linked_agents
@@ -235,7 +235,7 @@ function repoArchivalObjectToDraft(data: RepoArchivalObject) {
       '',
     publisher: null,
     totalItems: 1,
-    url: data.uri,
+    url: url,
   };
 
   const itemData: ItemDataDraft[] = data.instances.map((item, index) => ({

--- a/app/actions/aspaceSearch.ts
+++ b/app/actions/aspaceSearch.ts
@@ -204,6 +204,43 @@ function repoTopContainerToDraft(data: RepoTopContainer, url: string) {
  * repoArchivalObjectToDraft
  */
 
+const getItems = (data: RepoArchivalObject) => {
+  if (data.instances.length > 0) {
+    return data.instances.map((item, index) => ({
+      clientKey: `item-${index}`,
+      barcode: '',
+      box: '',
+      call_number:
+        callNumberOverrides.archivalObject?.item?.(item, data) ??
+        item.sub_container.top_container._resolved?.display_string ??
+        '',
+      copy_id: '',
+      description:
+        item.sub_container.top_container._resolved?.long_display_string ?? '',
+      folder: '',
+      location_code: data.repository._resolved?.slug ?? '',
+      location_name: data.repository._resolved?.name ?? '',
+      ms: '',
+    }));
+  } else {
+    if (callNumberOverrides.archivalObject?.allItems) {
+      const callNumbers = callNumberOverrides.archivalObject?.allItems(data);
+      return callNumbers.map((callNumber, index) => ({
+        clientKey: `item-${index}`,
+        barcode: '',
+        box: '',
+        call_number: callNumber ?? '',
+        copy_id: '',
+        description: callNumber ?? '',
+        folder: '',
+        location_code: data.repository._resolved?.slug ?? '',
+        location_name: data.repository._resolved?.name ?? '',
+        ms: '',
+      }));
+    }
+  }
+};
+
 function repoArchivalObjectToDraft(data: RepoArchivalObject, url: string) {
   const bibData: BibDataDraft = {
     author:
@@ -238,22 +275,7 @@ function repoArchivalObjectToDraft(data: RepoArchivalObject, url: string) {
     url: url,
   };
 
-  const itemData: ItemDataDraft[] = data.instances.map((item, index) => ({
-    clientKey: `item-${index}`,
-    barcode: '',
-    box: '',
-    call_number:
-      callNumberOverrides.archivalObject?.item?.(item, data) ??
-      item.sub_container.top_container._resolved?.display_string ??
-      '',
-    copy_id: '',
-    description:
-      item.sub_container.top_container._resolved?.long_display_string ?? '',
-    folder: '',
-    location_code: data.repository._resolved?.slug ?? '',
-    location_name: data.repository._resolved?.name ?? '',
-    ms: '',
-  }));
+  const itemData: ItemDataDraft[] = getItems(data) ?? [];
 
   return { bibData, itemData };
 }

--- a/app/actions/aspaceSearch.ts
+++ b/app/actions/aspaceSearch.ts
@@ -119,7 +119,9 @@ export async function searchByUrl(url: string, client: AspaceClient) {
         */
         if (parsed.instances.length == 0) {
           const parentResourceUrl = parsed.resource.ref;
+          console.log(`parentResourceUrl: ${parentResourceUrl}`);
           const originalUri = url.match(/\/repositories\/.*/);
+          console.log(`originalUri: ${originalUri}`);
           if (originalUri !== null) {
             extraInfo = await HandleMissingInstances(
               originalUri.toString(),

--- a/lib/catalogs/aspace/callNumberOverrides.ts
+++ b/lib/catalogs/aspace/callNumberOverrides.ts
@@ -48,6 +48,32 @@ const condenseItemRange = (items: (string | undefined)[]) => {
   return `${first} ... ${last} (${length} items)`;
 };
 
+const isWesternCollection = (data: RepoArchivalObject) => {
+  return (
+    data.ancestors.find((ancestor) => ancestor.ref == westernAncestorRef)
+      ?.ref == westernAncestorRef
+  );
+};
+
+const getWesternItemCallNumbers = (data: RepoArchivalObject) => {
+  const abstractNotes = data.notes.filter(
+    (
+      note,
+    ): note is Extract<
+      (typeof data.notes)[number],
+      { jsonmodel_type: 'note_singlepart' }
+    > =>
+      note.type == 'abstract' &&
+      note.jsonmodel_type == 'note_singlepart' &&
+      note.content.length > 0,
+  );
+  const abstractString = abstractNotes
+    .flatMap((note) => note.content)
+    .join(' ');
+  const matches = abstractString.match(callRegexWestern) || [];
+  return matches;
+};
+
 const overrides: AspaceCallNumberOverrides = {
   resources: {
     bib(data) {
@@ -59,28 +85,11 @@ const overrides: AspaceCallNumberOverrides = {
   },
   archivalObject: {
     bib(data) {
-      const isWesternCollection =
-        data.ancestors.find((ancestor) => ancestor.ref == westernAncestorRef)
-          ?.ref == westernAncestorRef;
-
-      if (isWesternCollection) {
-        const abstractNotes = data.notes.filter(
-          (
-            note,
-          ): note is Extract<
-            (typeof data.notes)[number],
-            { jsonmodel_type: 'note_singlepart' }
-          > =>
-            note.type == 'abstract' &&
-            note.jsonmodel_type == 'note_singlepart' &&
-            note.content.length > 0,
-        );
-        const abstractString = abstractNotes
-          .flatMap((note) => note.content)
-          .join(' ');
-        const matches = abstractString.match(callRegexWestern) || [];
-        return condenseItemRange(matches) ?? '';
+      if (isWesternCollection(data)) {
+        const matches = getWesternItemCallNumbers(data);
+        return condenseItemRange(matches);
       }
+      // else, if not Western...
       const displayString = data.instances
         .map(
           (instance) =>
@@ -92,7 +101,11 @@ const overrides: AspaceCallNumberOverrides = {
       // return displayString;
     },
 
-    item(itemData) {
+    item(itemData, data) {
+      if (isWesternCollection(data)) {
+        const matches = getWesternItemCallNumbers(data);
+      }
+      // else, if not western...
       const displayString =
         itemData.sub_container.top_container._resolved?.display_string;
       const matches = `${displayString?.match(callRegexMost)?.join(', ')}`;

--- a/lib/catalogs/aspace/callNumberOverrides.ts
+++ b/lib/catalogs/aspace/callNumberOverrides.ts
@@ -3,14 +3,18 @@ import type {
   RepoResources,
   RepoTopContainer,
 } from '@kenxirwin/archives-space-api-client';
+import { abort } from 'process';
 
 type ResourceInstance = RepoResources['instances'][number];
 type ArchivalObjectInstance = RepoArchivalObject['instances'][number];
 
 const callRegexMost = /\d+(A|M)\-[A-Z]\-\d+[A-Z]/g;
 // const callRegexRegGlobal = /\d+(A|M)\-[A-Z]\-\d+[A-Z]/g;
+//const callRegexWestern = /\[Range \d+[A-Z]\];* Box \d+/g;
 const callRegexWestern = /\[Range \d+[A-Z]\];* Box \d+/g;
 // const callRegexWesternGlobal = /\[Range \d+[A-Z]\];* Box \d+/g;
+
+const westernAncestorRef = '/repositories/2/resources/4';
 
 export interface AspaceCallNumberOverrides {
   resources?: {
@@ -36,21 +40,47 @@ export interface AspaceCallNumberOverrides {
  * implement whichever bib/item functions you need. See README.md for how
  * to set this file up so local edits don't conflict with upstream updates.
  */
+
+const condenseItemRange = (items: (string | undefined)[]) => {
+  const length = items.length;
+  const first = items[0];
+  const last = items[length - 1];
+  return `${first} ... ${last} (${length} items)`;
+};
+
 const overrides: AspaceCallNumberOverrides = {
   resources: {
     bib(data) {
       const itemCallNumbers = data.instances.map(
         (item) => item.sub_container.top_container._resolved?.display_string,
       );
-      const length = itemCallNumbers.length;
-      const first = itemCallNumbers[0];
-      const last = itemCallNumbers[length - 1];
-
-      return `${first} ... ${last} (${length} items)`;
+      return condenseItemRange(itemCallNumbers);
     },
   },
   archivalObject: {
     bib(data) {
+      const isWesternCollection =
+        data.ancestors.find((ancestor) => ancestor.ref == westernAncestorRef)
+          ?.ref == westernAncestorRef;
+
+      if (isWesternCollection) {
+        const abstractNotes = data.notes.filter(
+          (
+            note,
+          ): note is Extract<
+            (typeof data.notes)[number],
+            { jsonmodel_type: 'note_singlepart' }
+          > =>
+            note.type == 'abstract' &&
+            note.jsonmodel_type == 'note_singlepart' &&
+            note.content.length > 0,
+        );
+        const abstractString = abstractNotes
+          .flatMap((note) => note.content)
+          .join(' ');
+        const matches = abstractString.match(callRegexWestern) || [];
+        return condenseItemRange(matches) ?? '';
+      }
       const displayString = data.instances
         .map(
           (instance) =>

--- a/lib/catalogs/aspace/callNumberOverrides.ts
+++ b/lib/catalogs/aspace/callNumberOverrides.ts
@@ -3,6 +3,7 @@ import type {
   RepoResources,
   RepoTopContainer,
 } from '@kenxirwin/archives-space-api-client';
+import { ArchivalObjectExtraInfo } from '@/app/actions/aspaceSearch';
 import { match } from 'assert';
 import { Underdog } from 'next/font/google';
 import { abort } from 'process';
@@ -28,7 +29,10 @@ export interface AspaceCallNumberOverrides {
     item?: (data: RepoTopContainer) => string;
   };
   archivalObject?: {
-    bib?: (data: RepoArchivalObject) => string;
+    bib?: (
+      data: RepoArchivalObject,
+      extraInfo?: ArchivalObjectExtraInfo,
+    ) => string;
     item?: (item: ArchivalObjectInstance, data: RepoArchivalObject) => string;
     allItems?: (data: RepoArchivalObject) => string[];
   };
@@ -87,10 +91,17 @@ const overrides: AspaceCallNumberOverrides = {
     },
   },
   archivalObject: {
-    bib(data) {
+    bib(data, extraInfo) {
+      console.log('running archivalObject.bib override');
+      data && console.log('data present');
+      extraInfo && console.log(`extraInfo present`);
       if (isWesternCollection(data)) {
         const matches = getWesternItemCallNumbers(data);
         return condenseItemRange(matches);
+      }
+      if (extraInfo) {
+        console.log('trying to extra call number from extraInfo...');
+        return `${extraInfo.firstRecordArgusData.bibData.callNumber}... (${extraInfo.numItems} items)`;
       }
       // else, if not Western...
       const displayString = data.instances

--- a/lib/catalogs/aspace/callNumberOverrides.ts
+++ b/lib/catalogs/aspace/callNumberOverrides.ts
@@ -3,6 +3,8 @@ import type {
   RepoResources,
   RepoTopContainer,
 } from '@kenxirwin/archives-space-api-client';
+import { match } from 'assert';
+import { Underdog } from 'next/font/google';
 import { abort } from 'process';
 
 type ResourceInstance = RepoResources['instances'][number];
@@ -28,6 +30,7 @@ export interface AspaceCallNumberOverrides {
   archivalObject?: {
     bib?: (data: RepoArchivalObject) => string;
     item?: (item: ArchivalObjectInstance, data: RepoArchivalObject) => string;
+    allItems?: (data: RepoArchivalObject) => string[];
   };
 }
 
@@ -114,6 +117,14 @@ const overrides: AspaceCallNumberOverrides = {
       } else {
         return `${displayString || ''}`;
       }
+    },
+
+    allItems(data): string[] {
+      if (isWesternCollection(data)) {
+        const matches = getWesternItemCallNumbers(data);
+        return matches.filter((match) => match !== undefined) ?? [];
+      }
+      return [];
     },
   },
 };

--- a/lib/catalogs/aspace/callNumberOverrides.ts
+++ b/lib/catalogs/aspace/callNumberOverrides.ts
@@ -8,7 +8,7 @@ import { abort } from 'process';
 type ResourceInstance = RepoResources['instances'][number];
 type ArchivalObjectInstance = RepoArchivalObject['instances'][number];
 
-const callRegexMost = /\d+(A|M)\-[A-Z]\-\d+[A-Z]/g;
+const callRegexMost = /\[*\d+(A|M)\-[A-Z]\-\d+[A-Z]\]*/g;
 // const callRegexRegGlobal = /\d+(A|M)\-[A-Z]\-\d+[A-Z]/g;
 //const callRegexWestern = /\[Range \d+[A-Z]\];* Box \d+/g;
 const callRegexWestern = /\[Range \d+[A-Z]\];* Box \d+/g;

--- a/lib/catalogs/aspace/callNumberOverrides.ts
+++ b/lib/catalogs/aspace/callNumberOverrides.ts
@@ -37,11 +37,18 @@ export interface AspaceCallNumberOverrides {
  * to set this file up so local edits don't conflict with upstream updates.
  */
 const overrides: AspaceCallNumberOverrides = {
-  // resources: {
-  //   bib(data) {
-  //     return "return custom string";
-  //   },
-  // },
+  resources: {
+    bib(data) {
+      const itemCallNumbers = data.instances.map(
+        (item) => item.sub_container.top_container._resolved?.display_string,
+      );
+      const length = itemCallNumbers.length;
+      const first = itemCallNumbers[0];
+      const last = itemCallNumbers[length - 1];
+
+      return `${first} ... ${last} (${length} items)`;
+    },
+  },
   archivalObject: {
     bib(data) {
       const displayString = data.instances

--- a/lib/catalogs/aspace/callNumberOverrides.ts
+++ b/lib/catalogs/aspace/callNumberOverrides.ts
@@ -65,11 +65,11 @@ const overrides: AspaceCallNumberOverrides = {
     item(itemData) {
       const displayString =
         itemData.sub_container.top_container._resolved?.display_string;
-      const matches = `****${displayString?.match(callRegexMost)?.join(', ')}****`;
+      const matches = `${displayString?.match(callRegexMost)?.join(', ')}`;
       if (matches) {
         return matches;
       } else {
-        return `********${displayString || ''}********`;
+        return `${displayString || ''}`;
       }
     },
   },

--- a/lib/catalogs/aspace/callNumberOverrides.ts
+++ b/lib/catalogs/aspace/callNumberOverrides.ts
@@ -1,0 +1,45 @@
+import type {
+  RepoArchivalObject,
+  RepoResources,
+  RepoTopContainer,
+} from '@kenxirwin/archives-space-api-client';
+
+type ResourceInstance = RepoResources['instances'][number];
+type ArchivalObjectInstance = RepoArchivalObject['instances'][number];
+
+const callRegexReg = /\d+(A|M)\-[A-Z]\-\d+[A-Z]/;
+const callRegexWestern = /\[Range \d+[A-Z]\];* Box \d+/;
+
+export interface AspaceCallNumberOverrides {
+  resources?: {
+    bib?: (data: RepoResources) => string;
+    item?: (item: ResourceInstance, data: RepoResources) => string;
+  };
+  topContainer?: {
+    bib?: (data: RepoTopContainer) => string;
+    item?: (data: RepoTopContainer) => string;
+  };
+  archivalObject?: {
+    bib?: (data: RepoArchivalObject) => string;
+    item?: (item: ArchivalObjectInstance, data: RepoArchivalObject) => string;
+  };
+}
+
+/**
+ * Designated extension point for institution-specific ArchivesSpace
+ * call-number parsing. Ships with empty defaults, which preserves the
+ * built-in parsing logic in app/actions/aspaceSearch.ts.
+ *
+ * To customize for your installation, edit this file directly and
+ * implement whichever bib/item functions you need. See README.md for how
+ * to set this file up so local edits don't conflict with upstream updates.
+ */
+const overrides: AspaceCallNumberOverrides = {
+  // resources: {
+  //   bib(data) {
+  //     return "return custom string";
+  //   },
+  // },
+};
+
+export default overrides;

--- a/lib/catalogs/aspace/callNumberOverrides.ts
+++ b/lib/catalogs/aspace/callNumberOverrides.ts
@@ -7,8 +7,10 @@ import type {
 type ResourceInstance = RepoResources['instances'][number];
 type ArchivalObjectInstance = RepoArchivalObject['instances'][number];
 
-const callRegexReg = /\d+(A|M)\-[A-Z]\-\d+[A-Z]/;
-const callRegexWestern = /\[Range \d+[A-Z]\];* Box \d+/;
+const callRegexMost = /\d+(A|M)\-[A-Z]\-\d+[A-Z]/g;
+// const callRegexRegGlobal = /\d+(A|M)\-[A-Z]\-\d+[A-Z]/g;
+const callRegexWestern = /\[Range \d+[A-Z]\];* Box \d+/g;
+// const callRegexWesternGlobal = /\[Range \d+[A-Z]\];* Box \d+/g;
 
 export interface AspaceCallNumberOverrides {
   resources?: {
@@ -40,6 +42,30 @@ const overrides: AspaceCallNumberOverrides = {
   //     return "return custom string";
   //   },
   // },
+  archivalObject: {
+    bib(data) {
+      const displayString = data.instances
+        .map(
+          (instance) =>
+            instance.sub_container.top_container._resolved?.indicator,
+        )
+        .join('; ');
+      const matches = displayString.match(callRegexMost)?.join('; ');
+      return matches ?? displayString;
+      // return displayString;
+    },
+
+    item(itemData) {
+      const displayString =
+        itemData.sub_container.top_container._resolved?.display_string;
+      const matches = `****${displayString?.match(callRegexMost)?.join(', ')}****`;
+      if (matches) {
+        return matches;
+      } else {
+        return `********${displayString || ''}********`;
+      }
+    },
+  },
 };
 
 export default overrides;

--- a/lib/catalogs/aspace/provider.ts
+++ b/lib/catalogs/aspace/provider.ts
@@ -23,6 +23,7 @@ export const aspaceProvider: SearchableCatalogProvider = {
       }
     } catch (error) {
       console.error(`Error fetching data in aspace/provider/searchByAny`);
+      error instanceof Error && console.log(error.message);
       return { error: `Error fetching data in aspace/provider/searchByAny` };
     }
 

--- a/lib/findNodeByKeyValuePair.js
+++ b/lib/findNodeByKeyValuePair.js
@@ -1,0 +1,27 @@
+export function findNodeByKeyValuePair(tree, targetKey, targetValue) {
+  // Base case: check if current item is a valid object
+  if (tree === null || typeof tree !== 'object') {
+    return null;
+  }
+
+  // Check if current level has the target key and matching value
+  if (tree[targetKey] === targetValue) {
+    return tree;
+  }
+
+  // Handle arrays by iterating through elements
+  if (Array.isArray(tree)) {
+    for (const element of tree) {
+      const result = findNodeByKeyValuePair(element, targetKey, targetValue);
+      if (result) return result;
+    }
+  } else {
+    // Handle objects by iterating through keys using Object.values()
+    for (const value of Object.values(tree)) {
+      const result = findNodeByKeyValuePair(value, targetKey, targetValue);
+      if (result) return result;
+    }
+  }
+
+  return null;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,12 +54,12 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.11.0.tgz",
-      "integrity": "sha512-msK+Mvc8tmX3o8UTL6r9h7dodW9vPLvDjyVWLM0yLe5kuvvV5ag70O1qt5SXTCZd7HruS3MAuwUzn3PoQHoT3g==",
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.11.6.tgz",
+      "integrity": "sha512-cHAmZnSbr/z4HzyP00d8C7W9SjRZpdmzrS3q9SSdt176q3kw7KK6T0MBtn684tCx5E9sQPdCUB3Hvcu71hlWOA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.24.0",
+        "@clerk/shared": "^4.25.4",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -68,14 +68,14 @@
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.5.13.tgz",
-      "integrity": "sha512-8kFy9ZronzX33ukOm8LJ7IL8ioVTSRb8ZPN7xyz4ZEwFhjRpXwagJR3v/TSiwtlUEU0eydpFyT2pWPH8jvdf5A==",
+      "version": "7.5.19",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.5.19.tgz",
+      "integrity": "sha512-CDT6F751pN/783R3pQ75sbdZqRzCyWUwpEzIITx1ocJsNQeJDsOL3HLkFOTUsN3rZy8JxGxw27E3Ipbm2OUbJA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^3.11.0",
-        "@clerk/react": "^6.11.4",
-        "@clerk/shared": "^4.24.0",
+        "@clerk/backend": "^3.11.6",
+        "@clerk/react": "^6.12.4",
+        "@clerk/shared": "^4.25.4",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
@@ -89,12 +89,12 @@
       }
     },
     "node_modules/@clerk/react": {
-      "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.11.4.tgz",
-      "integrity": "sha512-3ft1broqXA6hSMXOhnVwEXDCqmaXSvYW65au6fOdhc26YPQbLL6e56FkJ4y/1c3uObpivuwe9MXj3ln4ZD0zmw==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.12.4.tgz",
+      "integrity": "sha512-YL4iS3F5o8TOW67v2RUPAvsIbSLTqcfgMQ+1/PYZCTf7DeGbAYfUzmAca1FGsSsrDFYV2sSV1piyscqVv7qQxQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.24.0",
+        "@clerk/shared": "^4.25.4",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.24.0.tgz",
-      "integrity": "sha512-QgAihmKS4ld3YSqSPMaKnzU4RGV+60k5khcjiz0xi4BCUST+UJAbV8f3Hw0osxq/Rw9rsxmRlcoxhEMsN5SOFA==",
+      "version": "4.25.4",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.25.4.tgz",
+      "integrity": "sha512-q2iAdjMOwDIPC+1HFgkF0yVL/fnRPSCjEkQ8dgSEVbAPJb/M8/CeKNfhSRKQcXFKiYYa4YrnYPH2F0J0YQaWiQ==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-core": "^5.100.6",
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -298,7 +298,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -912,9 +912,9 @@
       "license": "MIT"
     },
     "node_modules/@kenxirwin/archives-space-api-client": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@kenxirwin/archives-space-api-client/-/archives-space-api-client-0.2.1.tgz",
-      "integrity": "sha512-vD5F9iJDQYgWAeGwTDxJszvZvKlIIY+5TAAH/TIpFN2BUzncicXhaPCvVu0EH1Umm7xvxpW/9jS1xR6wtXbH6Q==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@kenxirwin/archives-space-api-client/-/archives-space-api-client-0.2.2.tgz",
+      "integrity": "sha512-0seJl0T1XEwfrG7QNE+ErWRzfgOm5QnJ75Rks3NSrqa+Fnuhn4RVRLEBExqziEQxCWbzmSEbGGgUqXs0rwZ02g==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -1777,17 +1777,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
-      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
+      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/type-utils": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/type-utils": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1800,15 +1800,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.63.0",
+        "@typescript-eslint/parser": "^8.64.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1816,16 +1816,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
-      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
+      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1841,14 +1841,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
-      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
+      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.63.0",
-        "@typescript-eslint/types": "^8.63.0",
+        "@typescript-eslint/tsconfig-utils": "^8.64.0",
+        "@typescript-eslint/types": "^8.64.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1863,14 +1863,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
-      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
+      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0"
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1881,9 +1881,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
-      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
+      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1898,15 +1898,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
-      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
+      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1923,9 +1923,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
-      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
+      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1937,16 +1937,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
-      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
+      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.63.0",
-        "@typescript-eslint/tsconfig-utils": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/project-service": "8.64.0",
+        "@typescript-eslint/tsconfig-utils": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2004,16 +2004,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
-      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
+      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0"
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2028,13 +2028,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
-      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
+      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/types": "8.64.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2713,9 +2713,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2849,9 +2849,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001802",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001802.tgz",
-      "integrity": "sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3372,9 +3372,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.4.tgz",
-      "integrity": "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.0.tgz",
+      "integrity": "sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3514,9 +3514,9 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
-      "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.4.0.tgz",
+      "integrity": "sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3618,9 +3618,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3629,8 +3629,8 @@
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -5361,9 +5361,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@clerk/nextjs": "^7.0.4",
         "@kenxirwin/alma-search": "^0.2.0",
-        "@kenxirwin/archives-space-api-client": "^0.2.1",
+        "@kenxirwin/archives-space-api-client": "^0.2.3",
         "@prisma/client": "^6.13.0",
         "bootstrap": "^5.3.7",
         "datatables.net-dt": "^2.3.2",
@@ -912,9 +912,9 @@
       "license": "MIT"
     },
     "node_modules/@kenxirwin/archives-space-api-client": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@kenxirwin/archives-space-api-client/-/archives-space-api-client-0.2.2.tgz",
-      "integrity": "sha512-0seJl0T1XEwfrG7QNE+ErWRzfgOm5QnJ75Rks3NSrqa+Fnuhn4RVRLEBExqziEQxCWbzmSEbGGgUqXs0rwZ02g==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@kenxirwin/archives-space-api-client/-/archives-space-api-client-0.2.3.tgz",
+      "integrity": "sha512-xKMIhqNpJK8S6OcrTN05CSUocCtJs9reJDny2h8KkPFii+i6RmGf9YSHbwQLP3HMUXRUrwyArHIXX3UwrURRhw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@clerk/nextjs": "^7.0.4",
         "@kenxirwin/alma-search": "^0.2.0",
-        "@kenxirwin/archives-space-api-client": "^0.3.0",
+        "@kenxirwin/archives-space-api-client": "^0.3.1",
         "@prisma/client": "^6.13.0",
         "bootstrap": "^5.3.7",
         "datatables.net-dt": "^2.3.2",
@@ -912,9 +912,9 @@
       "license": "MIT"
     },
     "node_modules/@kenxirwin/archives-space-api-client": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@kenxirwin/archives-space-api-client/-/archives-space-api-client-0.3.0.tgz",
-      "integrity": "sha512-2ameDJefFHlDtfiy3P2yJxo98NO+K8RSk5lP9s26uxBlkoVyO9sRZsvxWdzQ7U/sj4nNmkqCHlTrjBQZRNKCFQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@kenxirwin/archives-space-api-client/-/archives-space-api-client-0.3.1.tgz",
+      "integrity": "sha512-w63ALy7gd2drPRIF5Tp2LjBGLpuhHTkFamOXzd+zz+/APb366uBhKuyKSzvTjNLUBaT48JINbzNKfI65dgxLFA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@clerk/nextjs": "^7.0.4",
         "@kenxirwin/alma-search": "^0.2.0",
-        "@kenxirwin/archives-space-api-client": "^0.2.3",
+        "@kenxirwin/archives-space-api-client": "^0.3.0",
         "@prisma/client": "^6.13.0",
         "bootstrap": "^5.3.7",
         "datatables.net-dt": "^2.3.2",
@@ -912,9 +912,9 @@
       "license": "MIT"
     },
     "node_modules/@kenxirwin/archives-space-api-client": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@kenxirwin/archives-space-api-client/-/archives-space-api-client-0.2.3.tgz",
-      "integrity": "sha512-xKMIhqNpJK8S6OcrTN05CSUocCtJs9reJDny2h8KkPFii+i6RmGf9YSHbwQLP3HMUXRUrwyArHIXX3UwrURRhw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@kenxirwin/archives-space-api-client/-/archives-space-api-client-0.3.0.tgz",
+      "integrity": "sha512-2ameDJefFHlDtfiy3P2yJxo98NO+K8RSk5lP9s26uxBlkoVyO9sRZsvxWdzQ7U/sj4nNmkqCHlTrjBQZRNKCFQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@clerk/nextjs": "^7.0.4",
     "@kenxirwin/alma-search": "^0.2.0",
-    "@kenxirwin/archives-space-api-client": "^0.2.3",
+    "@kenxirwin/archives-space-api-client": "^0.3.0",
     "@prisma/client": "^6.13.0",
     "bootstrap": "^5.3.7",
     "datatables.net-dt": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@clerk/nextjs": "^7.0.4",
     "@kenxirwin/alma-search": "^0.2.0",
-    "@kenxirwin/archives-space-api-client": "^0.2.1",
+    "@kenxirwin/archives-space-api-client": "^0.2.2",
     "@prisma/client": "^6.13.0",
     "bootstrap": "^5.3.7",
     "datatables.net-dt": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@clerk/nextjs": "^7.0.4",
     "@kenxirwin/alma-search": "^0.2.0",
-    "@kenxirwin/archives-space-api-client": "^0.2.2",
+    "@kenxirwin/archives-space-api-client": "^0.2.3",
     "@prisma/client": "^6.13.0",
     "bootstrap": "^5.3.7",
     "datatables.net-dt": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@clerk/nextjs": "^7.0.4",
     "@kenxirwin/alma-search": "^0.2.0",
-    "@kenxirwin/archives-space-api-client": "^0.3.0",
+    "@kenxirwin/archives-space-api-client": "^0.3.1",
     "@prisma/client": "^6.13.0",
     "bootstrap": "^5.3.7",
     "datatables.net-dt": "^2.3.2",


### PR DESCRIPTION
* add lib/catalogs/aspace/callNumberOverrides.ts to create custom code to extract item and bib call numbers
* allows aspace items/callnumbers to be inferred from other content (e.g., if the call numbers are itemized in an "abstract" field, we can use a regular expression to find them and treat them as items.)
* for archival_objects with no entries in the instance array, it tries to get call number information from the "tree" of the parent resouce
* .gitattributes allows local institutions to have their own version of this file without overwriting it
