### PR TITLE
Bold Aspace item-level info on pull slips

### DIFF
--- a/components/RequestSlips/BibSection-aspace.tsx
+++ b/components/RequestSlips/BibSection-aspace.tsx
@@ -89,7 +89,7 @@ export const bibSectionAspace = (props: RequestSlipProps) => {
           item += counter;
           if (i == highlightedItemIndex)
             return (
-              <div key={i} className={styles.text}>
+              <div key={i} className={`${styles.text} ${styles.bold}`}>
                 {item}
               </div>
             );

--- a/components/RequestSlips/RequestSlipHalfPageHtml.module.css
+++ b/components/RequestSlips/RequestSlipHalfPageHtml.module.css
@@ -45,6 +45,10 @@
   margin-top: 0
 }
 
+.bold {
+  font-weight: bold;
+}
+
 .h4,
 .p {
   margin-top: 0;

--- a/lib/generateRequestSlipItems.ts
+++ b/lib/generateRequestSlipItems.ts
@@ -29,7 +29,8 @@ export default function generateRequestSlipItems(
         if (
           (item.copy_id && parseInt(item.copy_id) > 1) ||
           (item.description && item.description.length > 0) ||
-          item.location_code != entry.location_codes
+          item.location_code != entry.location_codes ||
+          (item.call_number && item.call_number !== entry.callNumber)
         ) {
           if (
             item.location_code &&


### PR DESCRIPTION
* closes #355
* adds call number for individual items to the item-level data presented on pull slip.