### PR TITLE
Add optional patron info to Projects (admin feature only)

### DIFF
--- a/app/(main-layout)/createProject/page.tsx
+++ b/app/(main-layout)/createProject/page.tsx
@@ -14,14 +14,19 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function CreateProjectPage() {
   const {
     user,
-    permissions: { isEditorOrAbove },
+    permissions: { isEditorOrAbove, isAdmin },
   } = await getUserInfo();
   const basePath = process.env.NEXT_PUBLIC_APP_BASEPATH ?? '/';
 
   if (isEditorOrAbove && user != undefined) {
     return (
       <>
-        <ProjectForm user={user} action={createProject} basePath={basePath} />
+        <ProjectForm
+          user={user}
+          action={createProject}
+          basePath={basePath}
+          isAdmin={isAdmin}
+        />
       </>
     );
   } else {

--- a/app/(main-layout)/editProject/[id]/page.tsx
+++ b/app/(main-layout)/editProject/[id]/page.tsx
@@ -58,6 +58,7 @@ export default async function EditProjectPage({
           user={currentUser}
           action={updateProject}
           project={project}
+          isAdmin={isAdmin}
           basePath={process.env.NEXT_PUBLIC_APP_BASEPATH ?? '/'}
         />
       </>

--- a/app/(main-layout)/quickSlip/alma/page.tsx
+++ b/app/(main-layout)/quickSlip/alma/page.tsx
@@ -15,14 +15,17 @@ export default async function quickSlipAlmaPage() {
     redirect('/');
   }
 
-  return (
-    <>
-      <h1>Lookup item for Quick Slip</h1>
-      <RecordSearchForm
-        quickSlip={true}
-        catalog="ALMA"
-        searchPlaceholder={CATALOG_SEARCH_PLACEHOLDER[resolvedCatalog]}
-      />
-    </>
-  );
+  if (user.user) {
+    return (
+      <>
+        <h1>Lookup item for Quick Slip</h1>
+        <RecordSearchForm
+          quickSlip={true}
+          catalog="ALMA"
+          searchPlaceholder={CATALOG_SEARCH_PLACEHOLDER[resolvedCatalog]}
+          user={user.user}
+        />
+      </>
+    );
+  }
 }

--- a/app/(main-layout)/quickSlip/alma/page.tsx
+++ b/app/(main-layout)/quickSlip/alma/page.tsx
@@ -23,7 +23,7 @@ export default async function quickSlipAlmaPage() {
           quickSlip={true}
           catalog="ALMA"
           searchPlaceholder={CATALOG_SEARCH_PLACEHOLDER[resolvedCatalog]}
-          user={user.user}
+          currentUser={user.user}
         />
       </>
     );

--- a/app/(main-layout)/quickSlip/custom/page.tsx
+++ b/app/(main-layout)/quickSlip/custom/page.tsx
@@ -11,14 +11,17 @@ export default async function quickSlipCustomPage() {
     redirect('/');
   }
 
-  return (
-    <>
-      <h1>Lookup item for Quick Slip</h1>
-      <CustomEntryForm
-        quickSlip={true}
-        nonOwnerEditor={nonOwnerEditor}
-        currentUserName={currentUserName}
-      />
-    </>
-  );
+  if (user.user) {
+    return (
+      <>
+        <h1>Lookup item for Quick Slip</h1>
+        <CustomEntryForm
+          quickSlip={true}
+          nonOwnerEditor={nonOwnerEditor}
+          currentUserName={currentUserName}
+          currentUser={user.user}
+        />
+      </>
+    );
+  }
 }

--- a/app/(printable-layout)/slipsRender/quickSlip/page.tsx
+++ b/app/(printable-layout)/slipsRender/quickSlip/page.tsx
@@ -1,7 +1,11 @@
 // app/(printable-layout)/slipsRender/quickSlip/page.tsx
 import * as z from 'zod';
 import { checkUser } from '@/lib/checkUser';
-import { isAllowedUserStatus, isAllowedAffiliation } from '@/lib/typeChecker';
+import {
+  isAllowedUserStatus,
+  isAllowedAffiliation,
+  isUserAffiliation,
+} from '@/lib/typeChecker';
 import { EntryWithItems } from '@/types/EntryWithItems';
 import { ProjectWithUserAndBib } from '@/types/ProjectWithUserAndBib';
 import generateRequestSlipItems from '@/lib/generateRequestSlipItems';
@@ -33,6 +37,9 @@ function createItemFromReq({
     subjects: [],
     title: 'Quick Slips',
     updatedAt: new Date(),
+    patronName: '',
+    patronAffiliation: 'Miami',
+    patronStatus: 'Other',
     user: {
       affiliation: 'Miami',
       clerkUserId: 'quick-slips',
@@ -92,6 +99,9 @@ function createItemFromReq({
       subjects: [],
       updatedAt: new Date(),
       userId: 'none',
+      patronAffiliation: 'Miami',
+      patronStatus: 'Other',
+      patronName: '',
     },
   };
 
@@ -115,6 +125,18 @@ function createItemFromReq({
     project.user.affiliation = params.userAffiliation;
   }
 
+  if (
+    params.hasOwnProperty('patronName') &&
+    typeof params.patronName == 'string'
+  ) {
+    project.patronName = params.patronName;
+  }
+  if (
+    params.hasOwnProperty('patronAffiliation') &&
+    isUserAffiliation(params.patronAffiliation)
+  ) {
+    project.patronAffiliation = params.patronAffiliation;
+  }
   if (params.hasOwnProperty('purpose') && typeof params.purpose == 'string') {
     project.purpose = params.purpose;
   }

--- a/app/(printable-layout)/slipsRender/quickSlip/page.tsx
+++ b/app/(printable-layout)/slipsRender/quickSlip/page.tsx
@@ -99,8 +99,8 @@ function createItemFromReq({
       subjects: [],
       updatedAt: new Date(),
       userId: 'none',
-      patronAffiliation: 'Miami',
-      patronStatus: 'Other',
+      patronAffiliation: project.patronAffiliation ?? 'Miami',
+      patronStatus: project.patronStatus ?? 'Other',
       patronName: '',
     },
   };
@@ -131,12 +131,22 @@ function createItemFromReq({
   ) {
     project.patronName = params.patronName;
   }
+
   if (
     params.hasOwnProperty('patronAffiliation') &&
     isUserAffiliation(params.patronAffiliation)
   ) {
     project.patronAffiliation = params.patronAffiliation;
   }
+
+  if (
+    params.hasOwnProperty('patronStatus') &&
+    typeof params.patronStatus == 'string' &&
+    isAllowedUserStatus(params.patronStatus)
+  ) {
+    project.patronStatus = params.patronStatus;
+  }
+
   if (params.hasOwnProperty('purpose') && typeof params.purpose == 'string') {
     project.purpose = params.purpose;
   }

--- a/app/actions/projectActions.ts
+++ b/app/actions/projectActions.ts
@@ -3,7 +3,7 @@ import logger from '@/lib/logger';
 import { db } from '@/lib/db';
 import getUserInfo from '@/lib/getUserInfo';
 import { getPermissions } from '@/lib/getUserInfo';
-import type { Prisma } from '@prisma/client';
+import type { Prisma, UserAffiliation, UserStatus } from '@prisma/client';
 import { Project } from '@prisma/client';
 import type { ProjectWithUserAndBib } from '@/types/ProjectWithUserAndBib';
 import entryAction from './addEntry';
@@ -42,6 +42,14 @@ export async function createProject(
     let patronName = null;
     if ((formData.get('patronName') as string) != '') {
       patronName = formData.get('patronName') as string;
+    }
+    let patronAffiliation = null;
+    if (formData.get('patronAffiliation') != '') {
+      patronAffiliation = formData.get('patronAffiliation') as UserAffiliation;
+    }
+    let patronStatus = null;
+    if (formData.get('patronStatus') != '') {
+      patronStatus = formData.get('patronStatus') as UserStatus;
     }
 
     const subjects = [subjectString];
@@ -92,6 +100,8 @@ export async function createProject(
           public: publicValue,
           subjects,
           patronName,
+          patronAffiliation,
+          patronStatus,
           userId: user.clerkUserId,
         },
         include: {
@@ -255,6 +265,14 @@ export async function updateProject(
     if ((formData.get('patronName') as string) != '') {
       patronName = formData.get('patronName') as string;
     }
+    let patronAffiliation = null;
+    if (formData.get('patronAffiliation') != '') {
+      patronAffiliation = formData.get('patronAffiliation') as UserAffiliation;
+    }
+    let patronStatus = null;
+    if (formData.get('patronStatus') != '') {
+      patronStatus = formData.get('patronStatus') as UserStatus;
+    }
     // const subjectsJson = formData.get('subjects') as string;
     // const subjects = JSON.parse(subjectsJson) || [];
     // console.log('***** subjectString', subjectString);
@@ -283,6 +301,8 @@ export async function updateProject(
         notes: notes || null,
         purpose,
         patronName,
+        patronAffiliation,
+        patronStatus,
         public: publicValue,
         subjects,
       },

--- a/app/actions/projectActions.ts
+++ b/app/actions/projectActions.ts
@@ -33,13 +33,17 @@ export async function createProject(
     if (!user) {
       return { success: false, error: 'User not authenticated' };
     }
-
     const titleValue = formData.get('title');
     //   const ownerValue = formData.get('userId');
     const notesValue = formData.get('notes') ?? '';
     const purposeValue = formData.get('purpose') ?? 'Other';
     const publicValue = formData.get('public') !== null;
     const subjectString = formData.get('subjects') as string;
+    let patronName = null;
+    if ((formData.get('patronName') as string) != '') {
+      patronName = formData.get('patronName') as string;
+    }
+
     const subjects = [subjectString];
     // const subjectsJson = formData.get('subjects') as string;
     // const subjects = JSON.parse(subjectsJson) || [];
@@ -87,6 +91,7 @@ export async function createProject(
           purpose,
           public: publicValue,
           subjects,
+          patronName,
           userId: user.clerkUserId,
         },
         include: {

--- a/app/actions/projectActions.ts
+++ b/app/actions/projectActions.ts
@@ -251,6 +251,10 @@ export async function updateProject(
     const publicValue = formData.get('public') !== null;
     const subjectString = formData.get('subjects') as string;
     const subjects = [subjectString];
+    let patronName = null;
+    if ((formData.get('patronName') as string) != '') {
+      patronName = formData.get('patronName') as string;
+    }
     // const subjectsJson = formData.get('subjects') as string;
     // const subjects = JSON.parse(subjectsJson) || [];
     // console.log('***** subjectString', subjectString);
@@ -278,6 +282,7 @@ export async function updateProject(
         title,
         notes: notes || null,
         purpose,
+        patronName,
         public: publicValue,
         subjects,
       },

--- a/components/BibResultsWrapper.tsx
+++ b/components/BibResultsWrapper.tsx
@@ -3,6 +3,8 @@ import { EntryWithItems } from '@/types/EntryWithItems';
 import BibEntryComponent from './BibEntryComponent';
 import HoldingEntry from './HoldingEntry';
 import Spinner from '@/components/ui/Spinner';
+import { currentUser } from '@clerk/nextjs/server';
+import { User } from '@prisma/client';
 
 interface BibResultsWrapperProps {
   projectId: number | undefined;
@@ -15,6 +17,7 @@ interface BibResultsWrapperProps {
   quickSlip?: boolean;
   currentUserName: string;
   nonOwnerEditor: boolean;
+  currentUser?: User;
 }
 
 export default function BibResultsWrapper({
@@ -28,6 +31,7 @@ export default function BibResultsWrapper({
   quickSlip,
   currentUserName,
   nonOwnerEditor,
+  currentUser,
 }: BibResultsWrapperProps) {
   if (searchActive) {
     return (
@@ -45,7 +49,10 @@ export default function BibResultsWrapper({
   } else {
     return (
       <>
-        <BibEntryComponent entry={holdingsData.bibData} extra={holdingsData.extra} />
+        <BibEntryComponent
+          entry={holdingsData.bibData}
+          extra={holdingsData.extra}
+        />
 
         <HoldingEntry
           items={holdingsData.itemData}
@@ -57,6 +64,7 @@ export default function BibResultsWrapper({
           quickSlip={quickSlip ?? false}
           nonOwnerEditor={nonOwnerEditor}
           currentUserName={currentUserName}
+          currentUser={currentUser}
         />
       </>
     );

--- a/components/CustomEntryForm.tsx
+++ b/components/CustomEntryForm.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import { LocationCode, inHouseLocationData } from '@/lib/locationCodes';
 import QuickSlipProjectInfo from './QuickSlipProjectInfo';
 import { useRouter } from 'next/navigation';
+import { User } from '@prisma/client';
 
 interface CustomEntryFormProps {
   projectId?: number;
@@ -20,6 +21,7 @@ interface CustomEntryFormProps {
   quickSlip?: boolean;
   nonOwnerEditor?: boolean;
   currentUserName: string;
+  currentUser?: User;
 }
 
 // interface LocationCode {
@@ -35,9 +37,12 @@ const CustomEntryForm = ({
   quickSlip = false,
   nonOwnerEditor = false,
   currentUserName,
+  currentUser,
 }: CustomEntryFormProps) => {
   const router = useRouter();
-  const [locations] = useState<LocationCode[]>(() => inHouseLocationData() ?? []);
+  const [locations] = useState<LocationCode[]>(
+    () => inHouseLocationData() ?? [],
+  );
   const [selectedLocation, setSelectedLocation] = useState<LocationCode | null>(
     null,
   );
@@ -332,7 +337,9 @@ const CustomEntryForm = ({
           </InputGroup>
         </div>
 
-        {quickSlip && <QuickSlipProjectInfo />}
+        {quickSlip && (
+          <QuickSlipProjectInfo currentUser={currentUser ?? null} />
+        )}
 
         {editable && (
           <Button

--- a/components/CustomEntryForm.tsx
+++ b/components/CustomEntryForm.tsx
@@ -117,6 +117,9 @@ const CustomEntryForm = ({
         'userStatus',
         'userAffiliation',
         'purpose',
+        'patronName',
+        'patronAffiliation',
+        'patronStatus',
       ]) {
         const value = formData.get(key);
         if (value) {

--- a/components/HoldingEntry.tsx
+++ b/components/HoldingEntry.tsx
@@ -11,6 +11,7 @@ import type { BibDataDraft, ItemDataDraft } from '@/lib/catalogs/types';
 import { inHouseLocationCodes } from '@/lib/locationCodes';
 import { useRouter } from 'next/navigation';
 import QuickSlipProjectInfo from './QuickSlipProjectInfo';
+import { User } from '@prisma/client';
 
 interface HoldingEntryProps {
   bibData: BibDataDraft;
@@ -22,6 +23,7 @@ interface HoldingEntryProps {
   quickSlip: boolean;
   nonOwnerEditor: boolean;
   currentUserName: string;
+  currentUser?: User;
 }
 
 const HoldingEntry = ({
@@ -34,6 +36,7 @@ const HoldingEntry = ({
   quickSlip,
   nonOwnerEditor,
   currentUserName,
+  currentUser,
 }: HoldingEntryProps) => {
   const router = useRouter();
 
@@ -85,7 +88,9 @@ const HoldingEntry = ({
       setSelectedItems((prev) => [...prev, item]);
     } else {
       setSelectedItems((prev) =>
-        prev.filter((selectedItem) => selectedItem.clientKey !== item.clientKey),
+        prev.filter(
+          (selectedItem) => selectedItem.clientKey !== item.clientKey,
+        ),
       );
     }
   };
@@ -107,7 +112,15 @@ const HoldingEntry = ({
       const qs = new URLSearchParams();
       qs.set('bibData', JSON.stringify(finalBibData));
       qs.set('itemData', JSON.stringify(selectedItems));
-      for (const key of ['userName', 'userStatus', 'userAffiliation', 'purpose']) {
+      for (const key of [
+        'userName',
+        'userStatus',
+        'userAffiliation',
+        'purpose',
+        'patronName',
+        'patronStatus',
+        'patronAffiliation',
+      ]) {
         const value = formData.get(key);
         if (value) {
           qs.set(key, value.toString());
@@ -126,9 +139,7 @@ const HoldingEntry = ({
     });
 
     if (error) {
-      toast.error(
-        `Failed to ${actionType === 'add' ? 'add' : 'update'} entry`,
-      );
+      toast.error(`Failed to ${actionType === 'add' ? 'add' : 'update'} entry`);
     } else {
       toast.success(
         `Entry ${actionType === 'add' ? 'added' : 'updated'} successfully`,
@@ -181,7 +192,7 @@ const HoldingEntry = ({
   return (
     <form ref={formRef} onSubmit={handleSubmit}>
       <div key={'holding'} className="mb-6 border p-3">
-        {quickSlip && <QuickSlipProjectInfo />}
+        {quickSlip && <QuickSlipProjectInfo currentUser={currentUser} />}
 
         <div>
           <InputGroup className="mb-4">
@@ -212,7 +223,9 @@ const HoldingEntry = ({
                 item.copy_id && parseInt(item.copy_id) > 1
                   ? `, Copy: ${item.copy_id}`
                   : '';
-              const description = item.description ? `, ${item.description}` : '';
+              const description = item.description
+                ? `, ${item.description}`
+                : '';
               const itemLabel =
                 sortedItems.length === 1
                   ? 'Sole Item'

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from 'react';
 // import { useRouter } from 'next/navigation'; // Changed from react-router-dom
 import { Project } from '@prisma/client';
 import { getProjectPurposes, getSubjects } from '@/lib/utils';
+import { UserAffiliation, UserStatus } from '@prisma/client';
 
 type ProjectActionResult =
   | { success: true; data: Project; error?: never }
@@ -49,6 +50,12 @@ export default function ProjectForm({
   const [selectedSubject, setSelectedSubject] = useState<string>(
     project?.subjects[0] ?? 'None',
   );
+  const [selectedPatronAffiliation, setSelectedPatronAffiliation] = useState(
+    project?.patronAffiliation ?? null,
+  );
+  const [selectedPatronStatus, setSelectedPatronStatus] = useState(
+    project?.patronStatus ?? null,
+  );
 
   const resolvedBasePath = basePath ?? '/';
 
@@ -73,6 +80,8 @@ export default function ProjectForm({
 
   const projectPurposes = getProjectPurposes();
   const projectSubjects = getSubjects();
+  const patronAffiliations = Object.values(UserAffiliation);
+  const patronStatuses = Object.values(UserStatus);
 
   const purposeSelectOptions = projectPurposes.map((item: string) => (
     <option key={item} value={item}>
@@ -81,6 +90,16 @@ export default function ProjectForm({
   ));
 
   const projectSubjectOptions = projectSubjects.map((item: string) => (
+    <option key={item} value={item}>
+      {item}
+    </option>
+  ));
+  const patronAffiliationOptions = patronAffiliations.map((item: string) => (
+    <option key={item} value={item}>
+      {item}
+    </option>
+  ));
+  const patronStatusOptions = patronStatuses.map((item: string) => (
     <option key={item} value={item}>
       {item}
     </option>
@@ -100,6 +119,20 @@ export default function ProjectForm({
   );
   projectSubjectOptions.unshift(blankSubjectPullDownOption);
 
+  const blankAffliationOption = (
+    <option key="none" value="">
+      No Patron Affliation Selected
+    </option>
+  );
+  patronAffiliationOptions.unshift(blankAffliationOption);
+
+  const blankPatronStatusOption = (
+    <option key="none" value="">
+      No Patron Status Selected
+    </option>
+  );
+  patronStatusOptions.unshift(blankPatronStatusOption);
+
   const handlePurposeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     // console.log(`Selected purpose: ${e.target.value}`);
     setSelectedPurpose(e.target.value);
@@ -112,6 +145,20 @@ export default function ProjectForm({
   const handleSubjectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     // console.log(`Selected purpose: ${e.target.value}`);
     setSelectedSubject(e.target.value);
+  };
+  const handlePatronAffiliationChange = (
+    e: React.ChangeEvent<HTMLSelectElement | null>,
+  ) => {
+    if (patronAffiliations.includes(e.target.value as UserAffiliation)) {
+      setSelectedPatronAffiliation(e.target.value as UserAffiliation);
+    }
+  };
+  const handlePatronStatusChange = (
+    e: React.ChangeEvent<HTMLSelectElement | null>,
+  ) => {
+    if (patronStatuses.includes(e.target.value as UserStatus)) {
+      setSelectedPatronStatus(e.target.value as UserStatus);
+    }
   };
 
   return (
@@ -147,7 +194,6 @@ export default function ProjectForm({
               {purposeSelectOptions}
             </Select>
           </div>
-
           <Label>Project Subject</Label>
           <Select
             id="subjects"
@@ -159,7 +205,6 @@ export default function ProjectForm({
           >
             {projectSubjectOptions}
           </Select>
-
           <div className="my-6">
             <Checkbox
               switch
@@ -170,7 +215,7 @@ export default function ProjectForm({
               onChange={handlePublicChange}
             />
           </div>
-
+          {/* only allow admins to create project on behalf of a patron */}
           {isAdmin && (
             <Card className="mb-5">
               <Card.Header className="bg-green-100">
@@ -188,10 +233,35 @@ export default function ProjectForm({
                     className="py-2"
                   />
                 </div>
+                <div className="mb-4">
+                  <Label>Patron Affiliation</Label>
+                  <Select
+                    id="patronAffiliation"
+                    name="patronAffiliation"
+                    // disabled={!editable}
+                    value={selectedPatronAffiliation ?? ''}
+                    onChange={handlePatronAffiliationChange}
+                    required={true}
+                  >
+                    {patronAffiliationOptions}
+                  </Select>
+                </div>
+                <div className="mb-4">
+                  <Label>Patron Status</Label>
+                  <Select
+                    id="patronStatus"
+                    name="patronStatus"
+                    // disabled={!editable}
+                    value={selectedPatronStatus ?? ''}
+                    onChange={handlePatronStatusChange}
+                    required={true}
+                  >
+                    {patronStatusOptions}
+                  </Select>
+                </div>
               </Card.Body>
             </Card>
           )}
-
           <div className="mb-6">
             <Label>Notes</Label>
             <Input
@@ -203,13 +273,10 @@ export default function ProjectForm({
               className="resize-none"
             />
           </div>
-
           <input type="hidden" name="userId" value={user?.clerkUserId} />
-
           {project && (
             <input type="hidden" name="projectId" value={project.id} />
           )}
-
           <div className="grid">
             <Button
               variant="primary"

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -229,7 +229,7 @@ export default function ProjectForm({
                     name="patronName"
                     defaultValue={project?.patronName || ''}
                     placeholder="Enter patron name..."
-                    required
+                    required={false}
                     className="py-2"
                   />
                 </div>
@@ -241,7 +241,7 @@ export default function ProjectForm({
                     // disabled={!editable}
                     value={selectedPatronAffiliation ?? ''}
                     onChange={handlePatronAffiliationChange}
-                    required={true}
+                    required={false}
                   >
                     {patronAffiliationOptions}
                   </Select>
@@ -254,7 +254,7 @@ export default function ProjectForm({
                     // disabled={!editable}
                     value={selectedPatronStatus ?? ''}
                     onChange={handlePatronStatusChange}
-                    required={true}
+                    required={false}
                   >
                     {patronStatusOptions}
                   </Select>

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -22,6 +22,7 @@ interface ProjectFormProps {
   user: User | null;
   project?: Project | null;
   basePath: string | null;
+  isAdmin: boolean;
   action: (
     prevState: unknown,
     formData: FormData,
@@ -36,6 +37,7 @@ export default function ProjectForm({
   project = undefined,
   action,
   basePath,
+  isAdmin,
 }: ProjectFormProps) {
   const [state, formAction] = useActionState(action, null);
   const [selectedPurpose, setSelectedPurpose] = useState<string>(
@@ -169,6 +171,27 @@ export default function ProjectForm({
             />
           </div>
 
+          {isAdmin && (
+            <Card className="mb-5">
+              <Card.Header className="bg-green-100">
+                Patron Info (only if creating project for a non-Argus user)
+              </Card.Header>
+              <Card.Body className="bg-green-50">
+                <div className="mb-4">
+                  <Label>Patron Name</Label>
+                  <Input
+                    type="text"
+                    name="patronName"
+                    defaultValue={project?.patronName || ''}
+                    placeholder="Enter patron name..."
+                    required
+                    className="py-2"
+                  />
+                </div>
+              </Card.Body>
+            </Card>
+          )}
+
           <div className="mb-6">
             <Label>Notes</Label>
             <Input
@@ -183,10 +206,17 @@ export default function ProjectForm({
 
           <input type="hidden" name="userId" value={user?.clerkUserId} />
 
-          {project && <input type="hidden" name="projectId" value={project.id} />}
+          {project && (
+            <input type="hidden" name="projectId" value={project.id} />
+          )}
 
           <div className="grid">
-            <Button variant="primary" type="submit" size="lg" className="w-full">
+            <Button
+              variant="primary"
+              type="submit"
+              size="lg"
+              className="w-full"
+            >
               {project ? 'Update Project' : 'Create New Project'}
             </Button>
           </div>

--- a/components/ProjectMetadata.tsx
+++ b/components/ProjectMetadata.tsx
@@ -37,6 +37,11 @@ const ProjectMetadata = ({
               Co-Editor: {ed.name}
             </Badge>
           ))}
+        {project.patronName && (
+          <Badge bg="light" className="ms-2 text-dark">
+            Patron: {project.patronName}
+          </Badge>
+        )}
 
         <div className="float-right">
           {project.subjects && project.subjects.length > 0 && (

--- a/components/QuickSlipProjectInfo.tsx
+++ b/components/QuickSlipProjectInfo.tsx
@@ -21,7 +21,7 @@ import {
 
 export default function QuickSlipProjectInfo() {
   const [userStatus, setUserStatus] = useState<UserStatus | undefined>(
-    undefined
+    undefined,
   );
   const [userAffiliation, setUserAffiliation] = useState<
     UserAffiliation | undefined
@@ -71,6 +71,9 @@ export default function QuickSlipProjectInfo() {
 
   return (
     <>
+      <Input type="hidden" name="userStatus" value="" />
+      <Input type="hidden" name="userAffiliation" value="" />
+      <Input type="hidden" name="userStatus" value="" />
       <InputGroup className="mb-4">
         <InputGroupText id="patron-label">Patron Name</InputGroupText>
         <Input
@@ -81,10 +84,10 @@ export default function QuickSlipProjectInfo() {
       </InputGroup>
 
       <InputGroup className="mb-4">
-        <InputGroupText id="status-label">User Status</InputGroupText>
+        <InputGroupText id="status-label">Patron Status</InputGroupText>
         <Select
           aria-labelledby="status-label"
-          name="userStatus"
+          name="patronStatus"
           onChange={handleChange('status')}
         >
           {statusPulldown.unshift(blankPullDownOption) && statusPulldown}
@@ -92,10 +95,10 @@ export default function QuickSlipProjectInfo() {
       </InputGroup>
 
       <InputGroup className="mb-4">
-        <InputGroupText id="affil-label">User Affiliation</InputGroupText>
+        <InputGroupText id="affil-label">Patron Affiliation</InputGroupText>
         <Select
           aria-labelledby="affil-label"
-          name="userAffiliation"
+          name="patronAffiliation"
           onChange={handleChange('affiliation')}
         >
           {affiliationPulldown.unshift(blankPullDownOption) &&

--- a/components/QuickSlipProjectInfo.tsx
+++ b/components/QuickSlipProjectInfo.tsx
@@ -3,7 +3,7 @@ import Input from '@/components/ui/Input';
 import Select from '@/components/ui/Select';
 import InputGroup, { InputGroupText } from '@/components/ui/InputGroup';
 import { useState } from 'react';
-import { UserAffiliation, UserStatus } from '@prisma/client';
+import { User, UserAffiliation, UserStatus } from '@prisma/client';
 import { getProjectPurposes } from '@/lib/utils';
 import {
   validStatuses,
@@ -19,7 +19,11 @@ import {
 // what can we do to make these more flexible? It doesn't look like we can devise types on the fly
 // like in a .env
 
-export default function QuickSlipProjectInfo() {
+export default function QuickSlipProjectInfo({
+  currentUser,
+}: {
+  currentUser?: User | null;
+}) {
   const [userStatus, setUserStatus] = useState<UserStatus | undefined>(
     undefined,
   );
@@ -71,15 +75,24 @@ export default function QuickSlipProjectInfo() {
 
   return (
     <>
-      <Input type="hidden" name="userStatus" value="" />
-      <Input type="hidden" name="userAffiliation" value="" />
-      <Input type="hidden" name="userStatus" value="" />
+      <Input type="hidden" name="userName" value={currentUser?.name ?? ''} />
+      <Input
+        type="hidden"
+        name="userAffiliation"
+        value={currentUser?.affiliation ?? ''}
+      />
+      <Input
+        type="hidden"
+        name="userStatus"
+        value={currentUser?.status ?? ''}
+      />
+
       <InputGroup className="mb-4">
         <InputGroupText id="patron-label">Patron Name</InputGroupText>
         <Input
           placeholder="Patron Name"
           aria-labelledby="patron-label"
-          name="userName"
+          name="patronName"
         />
       </InputGroup>
 

--- a/components/RecordSearchForm.tsx
+++ b/components/RecordSearchForm.tsx
@@ -31,7 +31,7 @@ type RecordSearchFormProps =
       quickSlip: true;
       catalog?: Catalog;
       searchPlaceholder: string;
-      user: User;
+      currentUser: User;
     };
 
 const RecordSearchForm = (props: RecordSearchFormProps) => {
@@ -43,13 +43,15 @@ const RecordSearchForm = (props: RecordSearchFormProps) => {
     nonOwnerEditor,
     currentUserName,
     placeholder,
-    catalog;
+    catalog,
+    currentUser;
   if (props.quickSlip) {
     quickSlip = true;
     userCanEditPage = true;
     projectId = undefined;
     catalog = 'ALMA' as Catalog;
     placeholder = props.searchPlaceholder;
+    currentUser = props.currentUser;
   } else {
     quickSlip = false;
     userCanEditPage = props.userCanEditPage;
@@ -121,6 +123,7 @@ const RecordSearchForm = (props: RecordSearchFormProps) => {
           quickSlip={quickSlip}
           currentUserName={currentUserName ?? 'unknown'}
           nonOwnerEditor={nonOwnerEditor ?? false}
+          currentUser={currentUser}
         />
         {process.env.NEXT_PUBLIC_IS_DEV_ENV && results && (
           <pre>{JSON.stringify(results, null, 2)}</pre>

--- a/components/RecordSearchForm.tsx
+++ b/components/RecordSearchForm.tsx
@@ -10,6 +10,12 @@ import { useSearchParams } from 'next/navigation';
 import type { Catalog } from '@prisma/client';
 import type { CatalogSearchResult } from '@/lib/catalogs/types';
 import BibResultsWrapper from './BibResultsWrapper';
+import { User } from '@prisma/client';
+
+// interface getUserResponse {
+//   user?: User | undefined;
+//   error?: string;
+// }
 
 type RecordSearchFormProps =
   | {
@@ -21,7 +27,12 @@ type RecordSearchFormProps =
       searchPlaceholder: string;
       catalog?: Catalog;
     }
-  | { quickSlip: true; catalog?: Catalog; searchPlaceholder: string };
+  | {
+      quickSlip: true;
+      catalog?: Catalog;
+      searchPlaceholder: string;
+      user: User;
+    };
 
 const RecordSearchForm = (props: RecordSearchFormProps) => {
   const formRef = useRef<HTMLFormElement>(null);

--- a/components/RequestSlips/RequestSlipHalfPageHtml.tsx
+++ b/components/RequestSlips/RequestSlipHalfPageHtml.tsx
@@ -68,6 +68,9 @@ export const RequestSlipHalfPage = (props: RequestSlipProps) => {
     box,
     folder,
     ms,
+    patronName,
+    patronAffiliation,
+    patronStatus,
     userName,
     userEmail,
     userAffiliation,
@@ -81,6 +84,11 @@ export const RequestSlipHalfPage = (props: RequestSlipProps) => {
   // console.log(`Added fields: ${userStatus}`);
 
   const bibSectionHtml = bibSection(props);
+
+  // patron status/affiliation overrides user status/affiliation
+  const status = patronStatus ?? userStatus;
+  const affiliation = patronAffiliation ?? userAffiliation;
+
   return (
     <article
       className={`${styles.sheetOuterLetterArticle} ${styles.sheetArticle}`}
@@ -121,14 +129,14 @@ export const RequestSlipHalfPage = (props: RequestSlipProps) => {
           <div className="flex flex-col">
             <div
               role="checkbox"
-              aria-checked={userAffiliation == 'Miami'}
+              aria-checked={affiliation == 'Miami'}
               className={styles.listGroupDiv}
             >
               Miami University
             </div>
             <div
               role="checkbox"
-              aria-checked={userAffiliation == 'Other'}
+              aria-checked={affiliation == 'Other'}
               className={styles.listGroupDiv}
             >
               Other
@@ -142,21 +150,21 @@ export const RequestSlipHalfPage = (props: RequestSlipProps) => {
               <div className={styles.listGroup}>
                 <div
                   role="checkbox"
-                  aria-checked={userStatus == 'Undergrad'}
+                  aria-checked={status == 'Undergrad'}
                   className={styles.listGroupDiv}
                 >
                   Undergraduate
                 </div>
                 <div
                   role="checkbox"
-                  aria-checked={userStatus == 'Graduate'}
+                  aria-checked={status == 'Graduate'}
                   className={styles.listGroupDiv}
                 >
                   Graduate
                 </div>
                 <div
                   role="checkbox"
-                  aria-checked={userStatus == 'Faculty'}
+                  aria-checked={status == 'Faculty'}
                   className={styles.listGroupDiv}
                 >
                   Faculty
@@ -167,21 +175,21 @@ export const RequestSlipHalfPage = (props: RequestSlipProps) => {
               <div className={styles.listGroup}>
                 <div
                   role="checkbox"
-                  aria-checked={userStatus == 'Alumni'}
+                  aria-checked={status == 'Alumni'}
                   className={styles.listGroupDiv}
                 >
                   Alumni
                 </div>
                 <div
                   role="checkbox"
-                  aria-checked={userStatus == 'Staff'}
+                  aria-checked={status == 'Staff'}
                   className={styles.listGroupDiv}
                 >
                   Staff
                 </div>
                 <div
                   role="checkbox"
-                  aria-checked={userStatus == 'Other'}
+                  aria-checked={status == 'Other'}
                   className={styles.listGroupDiv}
                 >
                   Other
@@ -249,6 +257,10 @@ export const RequestSlipHalfPage = (props: RequestSlipProps) => {
         </div>
         <div className={styles.column}>
           <div className="flex flex-col">
+            <div>
+              <span className={styles.label}>Patron name:</span>{' '}
+              <span className={styles.value}>{patronName}</span>
+            </div>
             <div>
               <span className={styles.label}>Project owner:</span>{' '}
               <span className={styles.value}>{userName}</span>

--- a/lib/generateRequestSlipItems.ts
+++ b/lib/generateRequestSlipItems.ts
@@ -72,6 +72,9 @@ export default function generateRequestSlipItems(
         folder: entry.items[0].folder ?? undefined,
         itemInfo: itemInfos, // full array of all items
         highlightedItemIndex: idx, // which one is current
+        patronName: project.patronName ?? undefined,
+        patronAffiliation: project.patronAffiliation ?? undefined,
+        patronStatus: project.patronStatus ?? undefined,
         userName: project?.user.name,
         userEmail: project?.user.email,
         userAffiliation: project?.user.affiliation ?? undefined,
@@ -96,6 +99,9 @@ export default function generateRequestSlipItems(
           ms: '',
           itemInfo: [],
           highlightedItemIndex: 0,
+          patronName: project.patronName ?? undefined,
+          patronAffiliation: project.patronAffiliation ?? undefined,
+          patronStatus: project.patronStatus ?? undefined,
           userName: project?.user.name,
           userEmail: project?.user.email,
           userAffiliation: project?.user.affiliation ?? undefined,

--- a/lib/typeChecker.ts
+++ b/lib/typeChecker.ts
@@ -1,4 +1,13 @@
-// import { UserStatus } from '@prisma/client';
+import { UserAffiliation } from '@prisma/client';
+
+export function isUserAffiliation(
+  value: string | string[] | undefined
+): value is UserAffiliation {
+  return (
+    typeof value === 'string' &&
+    (Object.values(UserAffiliation) as string[]).includes(value)
+  );
+}
 
 export type AllowedUserStatus =
   | 'Undergrad'

--- a/prisma/migrations/20260723175007_add_patron_to_project_info/migration.sql
+++ b/prisma/migrations/20260723175007_add_patron_to_project_info/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "patronAffiliation" "UserAffiliation",
+ADD COLUMN     "patronName" TEXT,
+ADD COLUMN     "patronStatus" "UserStatus";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,20 +25,23 @@ model User {
 }
 
 model Project {
-  id          Int        @id @default(autoincrement())
-  title       String
-  userId      String
-  notes       String?
-  needForDate DateTime?
-  createdAt   DateTime   @default(now())
-  updatedAt   DateTime   @updatedAt
-  purpose     String     @default("Other")
-  public      Boolean    @default(false)
-  subjects    String[]
-  status      String?
-  bibEntries  BibEntry[]
-  user        User       @relation("ProjectOwner", fields: [userId], references: [clerkUserId], onDelete: Cascade)
-  coEditors   User[]     @relation("ProjectCoEditors")
+  id                Int              @id @default(autoincrement())
+  title             String
+  userId            String
+  notes             String?
+  needForDate       DateTime?
+  createdAt         DateTime         @default(now())
+  updatedAt         DateTime         @updatedAt
+  purpose           String           @default("Other")
+  public            Boolean          @default(false)
+  subjects          String[]
+  status            String?
+  patronName        String?
+  patronAffiliation UserAffiliation?
+  patronStatus      UserStatus?
+  bibEntries        BibEntry[]
+  user              User             @relation("ProjectOwner", fields: [userId], references: [clerkUserId], onDelete: Cascade)
+  coEditors         User[]           @relation("ProjectCoEditors")
 }
 
 model BibEntry {

--- a/types/RequestSlipProps.ts
+++ b/types/RequestSlipProps.ts
@@ -12,6 +12,15 @@ export type RequestSlipProps = {
   notes?: string;
   itemInfo?: string[] | never[] | undefined;
   highlightedItemIndex?: number;
+  patronName?: string;
+  patronAffiliation?: 'Miami' | 'Other';
+  patronStatus?:
+    | 'Undergrad'
+    | 'Graduate'
+    | 'Faculty'
+    | 'Staff'
+    | 'Alumni'
+    | 'Other';
   userName?: string;
   userEmail?: string;
   userAffiliation?: 'Miami' | 'Other';


### PR DESCRIPTION
* Addresses #301 
* Allows admins to create/edit a project to have a patron name/affil/status (optional)
* Not available to non-admins
* If patron info is selected, it will show as part of the project metadata and be used on pull slips
* Updates Custom QuickSlip and Alma Quickslips to handle patron info as well